### PR TITLE
fix: allow AccountURL function to handle accounts in orgs spanning multiple regions

### DIFF
--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -55,9 +55,9 @@ func SelectCurrentAccount() string {
 }
 
 type CurrentAccount struct {
-	Account string `db:"account"`
+	Account     string `db:"account"`
 	RegionGroup string `db:"region_group"`
-	Region  string `db:"region"`
+	Region      string `db:"region"`
 }
 
 func ScanCurrentAccount(row *sqlx.Row) (*CurrentAccount, error) {

--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -51,7 +51,7 @@ var regionMapping = map[string]string{
 // SelectCurrentAccount returns the query that will return the current account, region_group, and region
 // the CURRENT_REGION() function returns the format region_group.region (e.g. PUBLIC.AWS_US_WEST_2) only when organizations have accounts in multiple region groups. Otherwise, this function returns the snowflake region without the region_group.
 func SelectCurrentAccount() string {
-	return `SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`
+	return `SELECT current_account AS "account", CASE WHEN CONTAINS(current_region, '.') THEN LEFT(current_region, POSITION('.' IN current_region) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(current_region, '.') THEN RIGHT(current_region, LENGTH(current_region) - POSITION('.' IN current_region)) ELSE current_region END AS "region" FROM (SELECT CURRENT_ACCOUNT() AS current_account, CURRENT_REGION() AS current_region);`
 }
 
 type CurrentAccount struct {

--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -51,7 +51,7 @@ var regionMapping = map[string]string{
 // SelectCurrentAccount returns the query that will return the current account, region_group, and region
 // the CURRENT_REGION() function returns the format region_group.region (e.g. PUBLIC.AWS_US_WEST_2) only when organizations have accounts in multiple region groups. Otherwise, this function returns the snowflake region without the region_group.
 func SelectCurrentAccount() string {
-	return `SELECT CURRENT_ACCOUNT() as "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`
+	return `SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`
 }
 
 type CurrentAccount struct {

--- a/pkg/snowflake/current_account.go
+++ b/pkg/snowflake/current_account.go
@@ -13,7 +13,7 @@ var regionMapping = map[string]string{
 	"aws_us_west_2":          "", // left black as this is the default
 	"aws_us_east_2":          "us-east-2.aws",
 	"aws_us_east_1":          "us-east-1",
-	"aws_us_east_1_gov":      "us-east-1-gov.aws",
+	"aws_us_gov_east_1":      "us-east-1-gov.aws",
 	"aws_ca_central_1":       "ca-central-1.aws",
 	"aws_sa_east_1":          "sa-east-1.aws",
 	"aws_eu_west_1":          "eu-west-1",
@@ -48,12 +48,15 @@ var regionMapping = map[string]string{
 	"azure_australiaeast":    "australia-east.azure",
 }
 
+// SelectCurrentAccount returns the query that will return the current account, region_group, and region
+// the CURRENT_REGION() function returns the format region_group.region (e.g. PUBLIC.AWS_US_WEST_2) only when organizations have accounts in multiple region groups. Otherwise, this function returns the snowflake region without the region_group.
 func SelectCurrentAccount() string {
-	return `SELECT CURRENT_ACCOUNT() AS "account", CURRENT_REGION() AS "region";`
+	return `SELECT CURRENT_ACCOUNT() as "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`
 }
 
 type CurrentAccount struct {
 	Account string `db:"account"`
+	RegionGroup string `db:"region_group"`
 	Region  string `db:"region"`
 }
 

--- a/pkg/snowflake/current_account_test.go
+++ b/pkg/snowflake/current_account_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCurrentAccountSelect(t *testing.T) {
 	r := require.New(t)
-	r.Equal(`SELECT CURRENT_ACCOUNT() as "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`, snowflake.SelectCurrentAccount())
+	r.Equal(`SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`, snowflake.SelectCurrentAccount())
 }
 
 func TestCurrentAccountRead(t *testing.T) {
@@ -66,7 +66,7 @@ func TestCurrentAccountRead(t *testing.T) {
 			sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
 
 			rows := sqlmock.NewRows([]string{"account", "region_group", "region"}).AddRow(tc.account, tc.region_group, tc.region)
-			mock.ExpectQuery(regexp.QuoteMeta(`SELECT CURRENT_ACCOUNT() as "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`)).WillReturnRows(rows)
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`)).WillReturnRows(rows)
 
 			acc, err := snowflake.ReadCurrentAccount(sqlxDB.DB)
 			r.NoError(err)

--- a/pkg/snowflake/current_account_test.go
+++ b/pkg/snowflake/current_account_test.go
@@ -17,10 +17,10 @@ func TestCurrentAccountSelect(t *testing.T) {
 
 func TestCurrentAccountRead(t *testing.T) {
 	type testCaseEntry struct {
-		account string
+		account      string
 		region_group string
-		region  string
-		url     string
+		region       string
+		url          string
 	}
 
 	testCases := map[string]testCaseEntry{

--- a/pkg/snowflake/current_account_test.go
+++ b/pkg/snowflake/current_account_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCurrentAccountSelect(t *testing.T) {
 	r := require.New(t)
-	r.Equal(`SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`, snowflake.SelectCurrentAccount())
+	r.Equal(`SELECT current_account AS "account", CASE WHEN CONTAINS(current_region, '.') THEN LEFT(current_region, POSITION('.' IN current_region) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(current_region, '.') THEN RIGHT(current_region, LENGTH(current_region) - POSITION('.' IN current_region)) ELSE current_region END AS "region" FROM (SELECT CURRENT_ACCOUNT() AS current_account, CURRENT_REGION() AS current_region);`, snowflake.SelectCurrentAccount())
 }
 
 func TestCurrentAccountRead(t *testing.T) {
@@ -66,7 +66,7 @@ func TestCurrentAccountRead(t *testing.T) {
 			sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
 
 			rows := sqlmock.NewRows([]string{"account", "region_group", "region"}).AddRow(tc.account, tc.region_group, tc.region)
-			mock.ExpectQuery(regexp.QuoteMeta(`SELECT CURRENT_ACCOUNT() AS "account",  CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN LEFT(CURRENT_REGION(), POSITION('.' IN CURRENT_REGION()) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(CURRENT_REGION(), '.') THEN RIGHT(CURRENT_REGION(), LENGTH(CURRENT_REGION()) - POSITION('.' IN CURRENT_REGION())) ELSE CURRENT_REGION() END AS "region";`)).WillReturnRows(rows)
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT current_account AS "account", CASE WHEN CONTAINS(current_region, '.') THEN LEFT(current_region, POSITION('.' IN current_region) - 1) ELSE 'PUBLIC' END AS "region_group", CASE WHEN CONTAINS(current_region, '.') THEN RIGHT(current_region, LENGTH(current_region) - POSITION('.' IN current_region)) ELSE current_region END AS "region" FROM (SELECT CURRENT_ACCOUNT() AS current_account, CURRENT_REGION() AS current_region);`)).WillReturnRows(rows)
 
 			acc, err := snowflake.ReadCurrentAccount(sqlxDB.DB)
 			r.NoError(err)


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->
This PR addresses an issue with the `snowflake_current_account` data source. Currently, it's not able to return the account url when the account belongs to an organization that spans multiple region groups. It's currently returning [this error](https://github.com/Snowflake-Labs/terraform-provider-snowflake/blob/538efa5ee9b0370e3090cd7fb867f3df4bbfd0ed/pkg/snowflake/current_account.go#L79C17-L79C95) when it tries to construct the account URL. The underlying cause of this error is that when an organization spans multiple regions, the current_account() function returns `<region_group>.<region>`, which is different behavior from when the organization's accounts are in a single region. 

The current_region logic is documented [here](https://docs.snowflake.com/en/sql-reference/functions/current_region#examples). 

This PR also addresses an error in the regionMapping for the `aws_us_gov_east_1` region. 

<!-- summary of changes -->
This PR changes the query that's used for fetching the current account and current region: it adds a new column to that query output to contain the `region_group`. In case there is ever a need for region_group in the future, I've added that to the CurrentAccount type. 

It also corrects the url string mapping for `aws_us_gov_east_1` region. 

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->


## References
<!-- issues documentation links, etc  -->

Closes issue [2067](https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/2067) 