### PR TITLE
chore: Add test time measurements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Snowflake-Labs/terraform-provider-snowflake
 
-go 1.22.10
+go 1.24.0
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/pkg/internal/measurement/test_measurements.go
+++ b/pkg/internal/measurement/test_measurements.go
@@ -1,0 +1,74 @@
+package measurement
+
+import (
+	"fmt"
+	"golang.org/x/exp/maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type TestMeasurement struct {
+	TestName        string
+	Duration        time.Duration
+	SubMeasurements map[string]*TestMeasurement
+}
+
+func NewTestMeasurement(t *testing.T) *TestMeasurement {
+	m := new(TestMeasurement)
+	m.TestName = t.Name()
+	m.SubMeasurements = make(map[string]*TestMeasurement)
+	return m
+}
+
+type TestMeasurements struct {
+	Measurements map[string]*TestMeasurement
+}
+
+func NewTestMeasurements() *TestMeasurements {
+	return &TestMeasurements{
+		Measurements: make(map[string]*TestMeasurement),
+	}
+}
+
+func PrintMeasurementSummary(measurements *TestMeasurements, truncateDuration time.Duration) {
+	fmt.Println("Summary of test measurements (sorted by execution time)")
+	values := maps.Values(measurements.Measurements)
+	slices.SortFunc(values, func(a, b *TestMeasurement) int {
+		return int(b.Duration.Nanoseconds() - a.Duration.Nanoseconds())
+	})
+	printMeasurements(0, values, truncateDuration)
+}
+
+func printMeasurements(level int, measurements []*TestMeasurement, truncateDuration time.Duration) {
+	for _, measurement := range measurements {
+		fmt.Printf("%-10s%s%s\n", measurement.Duration.Truncate(truncateDuration), strings.Repeat(" → ", level), measurement.TestName)
+		printMeasurements(level+1, maps.Values(measurement.SubMeasurements), truncateDuration)
+	}
+}
+
+func MeasureTestTime(testMeasurements *TestMeasurements, t *testing.T) {
+	t.Helper()
+	start := time.Now()
+	m := NewTestMeasurement(t)
+	testNameParts := strings.Split(m.TestName, "/")
+	if len(testNameParts) == 1 {
+		if _, ok := testMeasurements.Measurements[m.TestName]; ok {
+			panic("this shouldn't happen")
+		}
+
+		testMeasurements.Measurements[m.TestName] = m
+	} else {
+		currentMeasurement := testMeasurements.Measurements[testNameParts[0]]
+		for index, part := range testNameParts[1:] {
+			if value, ok := currentMeasurement.SubMeasurements[part]; ok {
+				currentMeasurement = value
+			} else {
+				m.TestName = strings.Join(testNameParts[index+1:], "/")
+				currentMeasurement.SubMeasurements[part] = m
+			}
+		}
+	}
+	t.Cleanup(func() { m.Duration = time.Now().Sub(start) })
+}

--- a/pkg/sdk/accounts_test.go
+++ b/pkg/sdk/accounts_test.go
@@ -10,53 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestATest(t *testing.T) {
-	measureTest(t)
-	// TODO: TestTest not found; add it to the map
+func TestATest(tt *testing.T) {
+	t := measureTest(tt)
 
-	t.Run("level one", func(t *testing.T) {
-		measureTest(t)
-		// TODO: TestTest/level_one (TestTest found; add level_one as sub-measurement)
-
-		t.Run("level two", func(t *testing.T) {
-			measureTest(t)
-			// TODO: TestTest/level_one/level_two (TestTest found;
-
-			t.Run("level three", func(t *testing.T) {
-				measureTest(t)
+	t.Run("level one", func(t *T) {
+		t.Run("level two", func(t *T) {
+			t.Run("level three", func(t *T) {
+				assert.Equal(t, 1, 1)
 			})
 		})
 
-		t.Run("2nd level two", func(t *testing.T) {
-			measureTest(t)
-
-			t.Run("2nd level three", func(t *testing.T) {
-				measureTest(t)
-			})
+		t.Run("2nd level two", func(t *T) {
+			t.Run("2nd level three", func(t *T) {})
 		})
 	})
 
-	t.Run("2nd level one", func(t *testing.T) {
-		measureTest(t)
-		// TODO: TestTest/level_one (TestTest found; add level_one as sub-measurement)
-
-		t.Run("level two", func(t *testing.T) {
-			measureTest(t)
-			// TODO: TestTest/level_one/level_two (TestTest found;
-
-			t.Run("level three", func(t *testing.T) {
-				measureTest(t)
-
-				t.Run("level four", func(t *testing.T) {
-					measureTest(t)
-
-					t.Run("level five", func(t *testing.T) {
-						measureTest(t)
-					})
-
-					t.Run("2nd level five", func(t *testing.T) {
-						measureTest(t)
-					})
+	t.Run("2nd level one", func(t *T) {
+		t.Run("level two", func(t *T) {
+			t.Run("level three", func(t *T) {
+				t.Run("level four", func(t *T) {
+					t.Run("level five", func(t *T) {})
+					t.Run("2nd level five", func(t *T) {})
 				})
 			})
 		})

--- a/pkg/sdk/accounts_test.go
+++ b/pkg/sdk/accounts_test.go
@@ -10,8 +10,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestATest(t *testing.T) {
+	measureTest(t)
+	// TODO: TestTest not found; add it to the map
+
+	t.Run("level one", func(t *testing.T) {
+		measureTest(t)
+		// TODO: TestTest/level_one (TestTest found; add level_one as sub-measurement)
+
+		t.Run("level two", func(t *testing.T) {
+			measureTest(t)
+			// TODO: TestTest/level_one/level_two (TestTest found;
+
+			t.Run("level three", func(t *testing.T) {
+				measureTest(t)
+			})
+		})
+
+		t.Run("2nd level two", func(t *testing.T) {
+			measureTest(t)
+
+			t.Run("2nd level three", func(t *testing.T) {
+				measureTest(t)
+			})
+		})
+	})
+
+	t.Run("2nd level one", func(t *testing.T) {
+		measureTest(t)
+		// TODO: TestTest/level_one (TestTest found; add level_one as sub-measurement)
+
+		t.Run("level two", func(t *testing.T) {
+			measureTest(t)
+			// TODO: TestTest/level_one/level_two (TestTest found;
+
+			t.Run("level three", func(t *testing.T) {
+				measureTest(t)
+
+				t.Run("level four", func(t *testing.T) {
+					measureTest(t)
+
+					t.Run("level five", func(t *testing.T) {
+						measureTest(t)
+					})
+
+					t.Run("2nd level five", func(t *testing.T) {
+						measureTest(t)
+					})
+				})
+			})
+		})
+	})
+}
+
 func TestAccountCreate(t *testing.T) {
+	measureTest(t)
+
 	t.Run("simplest case", func(t *testing.T) {
+		measureTest(t)
 		id := randomAccountObjectIdentifier()
 		password := random.Password()
 		opts := &CreateAccountOptions{
@@ -25,6 +81,7 @@ func TestAccountCreate(t *testing.T) {
 	})
 
 	t.Run("every option", func(t *testing.T) {
+		measureTest(t)
 		id := randomAccountObjectIdentifier()
 		key := random.Password()
 		opts := &CreateAccountOptions{
@@ -46,6 +103,7 @@ func TestAccountCreate(t *testing.T) {
 	})
 
 	t.Run("static password", func(t *testing.T) {
+		measureTest(t)
 		id := randomAccountObjectIdentifier()
 		password := random.Password()
 		opts := &CreateAccountOptions{
@@ -66,6 +124,8 @@ func TestAccountCreate(t *testing.T) {
 }
 
 func TestAccountAlter(t *testing.T) {
+	measureTest(t)
+
 	t.Run("validation: exactly one value set in AccountSet - nothing set", func(t *testing.T) {
 		opts := &AlterAccountOptions{
 			Set: &AccountSet{},
@@ -357,6 +417,8 @@ func TestAccountAlter(t *testing.T) {
 }
 
 func TestAccountDrop(t *testing.T) {
+	measureTest(t)
+
 	t.Run("validate: empty options", func(t *testing.T) {
 		opts := &DropAccountOptions{}
 		assertOptsInvalidJoinedErrors(t, opts, ErrInvalidObjectIdentifier)
@@ -383,6 +445,8 @@ func TestAccountDrop(t *testing.T) {
 }
 
 func TestAccountShow(t *testing.T) {
+	measureTest(t)
+
 	t.Run("empty options", func(t *testing.T) {
 		opts := &ShowAccountOptions{}
 		assertOptsValidAndSQLEquals(t, opts, `SHOW ACCOUNTS`)
@@ -409,6 +473,8 @@ func TestAccountShow(t *testing.T) {
 }
 
 func TestToAccountCreateResponse(t *testing.T) {
+	measureTest(t)
+
 	testCases := []struct {
 		Name           string
 		RawInput       string
@@ -522,6 +588,8 @@ func TestToAccountCreateResponse(t *testing.T) {
 }
 
 func TestToAccountEdition(t *testing.T) {
+	measureTest(t)
+
 	type test struct {
 		input string
 		want  AccountEdition

--- a/pkg/sdk/alerts_test.go
+++ b/pkg/sdk/alerts_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestAlertCreate(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	t.Run("with complete options", func(t *testing.T) {
@@ -31,6 +32,7 @@ func TestAlertCreate(t *testing.T) {
 }
 
 func TestAlertAlter(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	t.Run("fail without alter action specified", func(t *testing.T) {
@@ -115,6 +117,7 @@ func TestAlertAlter(t *testing.T) {
 }
 
 func TestAlertDrop(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	t.Run("empty options", func(t *testing.T) {
@@ -139,6 +142,7 @@ func TestAlertDrop(t *testing.T) {
 }
 
 func TestAlertShow(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	t.Run("empty options", func(t *testing.T) {
@@ -212,6 +216,7 @@ func TestAlertShow(t *testing.T) {
 }
 
 func TestAlertDescribe(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	t.Run("empty options", func(t *testing.T) {

--- a/pkg/sdk/api_integrations_gen_test.go
+++ b/pkg/sdk/api_integrations_gen_test.go
@@ -14,6 +14,7 @@ const (
 )
 
 func TestApiIntegrations_Create(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	// Minimal valid CreateApiIntegrationOptions for AWS
@@ -123,6 +124,7 @@ func TestApiIntegrations_Create(t *testing.T) {
 }
 
 func TestApiIntegrations_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	// Minimal valid AlterApiIntegrationOptions
@@ -303,6 +305,7 @@ func TestApiIntegrations_Alter(t *testing.T) {
 }
 
 func TestApiIntegrations_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	// Minimal valid DropApiIntegrationOptions
@@ -331,6 +334,7 @@ func TestApiIntegrations_Drop(t *testing.T) {
 }
 
 func TestApiIntegrations_Show(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	// Minimal valid ShowApiIntegrationOptions
@@ -358,6 +362,7 @@ func TestApiIntegrations_Show(t *testing.T) {
 }
 
 func TestApiIntegrations_Describe(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	// Minimal valid DescribeApiIntegrationOptions

--- a/pkg/sdk/application_packages_gen_test.go
+++ b/pkg/sdk/application_packages_gen_test.go
@@ -3,6 +3,7 @@ package sdk
 import "testing"
 
 func TestApplicationPackages_Create(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *CreateApplicationPackageOptions {
@@ -42,6 +43,7 @@ func TestApplicationPackages_Create(t *testing.T) {
 }
 
 func TestApplicationPackages_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *AlterApplicationPackageOptions {
@@ -210,6 +212,7 @@ func TestApplicationPackages_Alter(t *testing.T) {
 }
 
 func TestApplicationPackages_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *DropApplicationPackageOptions {
@@ -237,6 +240,7 @@ func TestApplicationPackages_Drop(t *testing.T) {
 }
 
 func TestApplicationPackages_Show(t *testing.T) {
+	measureTest(t)
 	defaultOpts := func() *ShowApplicationPackageOptions {
 		return &ShowApplicationPackageOptions{}
 	}

--- a/pkg/sdk/application_roles_gen_test.go
+++ b/pkg/sdk/application_roles_gen_test.go
@@ -3,6 +3,7 @@ package sdk
 import "testing"
 
 func TestApplicationRoles_Grant(t *testing.T) {
+	measureTest(t)
 	id := randomDatabaseObjectIdentifier()
 
 	// Minimal valid GrantApplicationRoleOptions
@@ -59,6 +60,7 @@ func TestApplicationRoles_Grant(t *testing.T) {
 }
 
 func TestApplicationRoles_Revoke(t *testing.T) {
+	measureTest(t)
 	id := randomDatabaseObjectIdentifier()
 
 	// Minimal valid RevokeApplicationRoleOptions
@@ -110,6 +112,7 @@ func TestApplicationRoles_Revoke(t *testing.T) {
 }
 
 func TestApplicationRoles_Show(t *testing.T) {
+	measureTest(t)
 	appId := randomAccountObjectIdentifier()
 
 	// Minimal valid ShowApplicationRoleOptions

--- a/pkg/sdk/applications_gen_test.go
+++ b/pkg/sdk/applications_gen_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestApplications_Create(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 	pid := randomAccountObjectIdentifier()
 
@@ -91,6 +92,7 @@ func TestApplications_Create(t *testing.T) {
 }
 
 func TestApplications_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *AlterApplicationOptions {
@@ -228,6 +230,7 @@ func TestApplications_Alter(t *testing.T) {
 }
 
 func TestApplications_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *DropApplicationOptions {
@@ -255,6 +258,7 @@ func TestApplications_Drop(t *testing.T) {
 }
 
 func TestApplications_Describe(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 
 	defaultOpts := func() *DescribeApplicationOptions {
@@ -281,6 +285,7 @@ func TestApplications_Describe(t *testing.T) {
 }
 
 func TestApplications_Show(t *testing.T) {
+	measureTest(t)
 	defaultOpts := func() *ShowApplicationOptions {
 		return &ShowApplicationOptions{}
 	}

--- a/pkg/sdk/authentication_policies_gen_test.go
+++ b/pkg/sdk/authentication_policies_gen_test.go
@@ -3,6 +3,7 @@ package sdk
 import "testing"
 
 func TestAuthenticationPolicies_Create(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 	// Minimal valid CreateAuthenticationPolicyOptions
 	defaultOpts := func() *CreateAuthenticationPolicyOptions {
@@ -62,6 +63,7 @@ func TestAuthenticationPolicies_Create(t *testing.T) {
 }
 
 func TestAuthenticationPolicies_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 	// Minimal valid AlterAuthenticationPolicyOptions
 	defaultOpts := func() *AlterAuthenticationPolicyOptions {
@@ -166,6 +168,7 @@ func TestAuthenticationPolicies_Alter(t *testing.T) {
 }
 
 func TestAuthenticationPolicies_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 	// Minimal valid DropAuthenticationPolicyOptions
 	defaultOpts := func() *DropAuthenticationPolicyOptions {
@@ -192,6 +195,7 @@ func TestAuthenticationPolicies_Drop(t *testing.T) {
 }
 
 func TestAuthenticationPolicies_Show(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 	// Minimal valid ShowAuthenticationPolicyOptions
 	defaultOpts := func() *ShowAuthenticationPolicyOptions {
@@ -226,6 +230,7 @@ func TestAuthenticationPolicies_Show(t *testing.T) {
 }
 
 func TestAuthenticationPolicies_Describe(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 	// Minimal valid DescribeAuthenticationPolicyOptions
 	defaultOpts := func() *DescribeAuthenticationPolicyOptions {

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -13,18 +13,21 @@ import (
 // TODO [SNOW-1827331]: Move the rest of the tests to testint package
 
 func TestClient_ping(t *testing.T) {
+	measureTest(t)
 	client := defaultTestClient(t)
 	err := client.Ping()
 	require.NoError(t, err)
 }
 
 func TestClient_close(t *testing.T) {
+	measureTest(t)
 	client := defaultTestClient(t)
 	err := client.Close()
 	require.NoError(t, err)
 }
 
 func TestClient_exec(t *testing.T) {
+	measureTest(t)
 	client := defaultTestClient(t)
 	ctx := context.Background()
 	_, err := client.exec(ctx, "SELECT 1")
@@ -32,6 +35,7 @@ func TestClient_exec(t *testing.T) {
 }
 
 func TestClient_query(t *testing.T) {
+	measureTest(t)
 	client := defaultTestClient(t)
 	ctx := context.Background()
 	rows := []struct {
@@ -45,6 +49,7 @@ func TestClient_query(t *testing.T) {
 }
 
 func TestClient_queryOne(t *testing.T) {
+	measureTest(t)
 	client := defaultTestClient(t)
 	ctx := context.Background()
 	row := struct {
@@ -56,6 +61,7 @@ func TestClient_queryOne(t *testing.T) {
 }
 
 func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
+	measureTest(t)
 	t.Run("get default gosnowflake driver logging level", func(t *testing.T) {
 		config := DefaultConfig()
 		_, err := NewClient(config)

--- a/pkg/sdk/comments_test.go
+++ b/pkg/sdk/comments_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestComments(t *testing.T) {
+	measureTest(t)
 	t.Run("set on schema", func(t *testing.T) {
 		id := randomDatabaseObjectIdentifier()
 		opts := &SetCommentOptions{

--- a/pkg/sdk/common_table_types_test.go
+++ b/pkg/sdk/common_table_types_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func Test_ToColumnConstraintType(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  ColumnConstraintType
@@ -52,6 +53,7 @@ func Test_ToColumnConstraintType(t *testing.T) {
 }
 
 func Test_ToMatchType(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  MatchType
@@ -97,6 +99,7 @@ func Test_ToMatchType(t *testing.T) {
 }
 
 func Test_ToForeignKeyAction(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  ForeignKeyAction

--- a/pkg/sdk/common_types_test.go
+++ b/pkg/sdk/common_types_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Test_ToStringProperty(t *testing.T) {
+	measureTest(t)
 	t.Run("with empty property row", func(t *testing.T) {
 		row := &propertyRow{
 			Value:        "null",
@@ -35,6 +36,7 @@ func Test_ToStringProperty(t *testing.T) {
 }
 
 func Test_ToIntProperty(t *testing.T) {
+	measureTest(t)
 	t.Run("with empty property row", func(t *testing.T) {
 		row := &propertyRow{
 			Value:        "null",
@@ -106,6 +108,7 @@ func Test_ToIntProperty(t *testing.T) {
 }
 
 func Test_ToBoolProperty(t *testing.T) {
+	measureTest(t)
 	t.Run("with empty property row", func(t *testing.T) {
 		row := &propertyRow{
 			Value:        "null",
@@ -132,6 +135,7 @@ func Test_ToBoolProperty(t *testing.T) {
 }
 
 func Test_ToFloatProperty(t *testing.T) {
+	measureTest(t)
 	t.Run("with empty property row", func(t *testing.T) {
 		row := &propertyRow{
 			Value:        "null",
@@ -194,6 +198,7 @@ func Test_ToFloatProperty(t *testing.T) {
 }
 
 func TestToStorageSerializationPolicy(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -226,6 +231,7 @@ func TestToStorageSerializationPolicy(t *testing.T) {
 }
 
 func TestToLogLevel(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -263,6 +269,7 @@ func TestToLogLevel(t *testing.T) {
 }
 
 func Test_ToExecuteAs(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -295,6 +302,7 @@ func Test_ToExecuteAs(t *testing.T) {
 }
 
 func Test_ToNullInputBehavior(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -328,6 +336,7 @@ func Test_ToNullInputBehavior(t *testing.T) {
 }
 
 func Test_ToReturnResultsBehavior(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -360,6 +369,7 @@ func Test_ToReturnResultsBehavior(t *testing.T) {
 }
 
 func TestToTraceLevel(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name     string
 		Input    string
@@ -393,6 +403,7 @@ func TestToTraceLevel(t *testing.T) {
 }
 
 func Test_ToMetricLevel(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name          string
 		Input         string
@@ -426,6 +437,7 @@ func Test_ToMetricLevel(t *testing.T) {
 }
 
 func Test_ToAutoEventLogging(t *testing.T) {
+	measureTest(t)
 	testCases := []struct {
 		Name          string
 		Input         string

--- a/pkg/sdk/config_test.go
+++ b/pkg/sdk/config_test.go
@@ -19,6 +19,7 @@ import (
 
 // TODO [SNOW-1827309]: use toml config builder instead of hardcoding
 func TestLoadConfigFile(t *testing.T) {
+	measureTest(t)
 	c := `
 	[default]
 	accountname='TEST_ACCOUNT'
@@ -51,6 +52,7 @@ func TestLoadConfigFile(t *testing.T) {
 }
 
 func TestLoadConfigFileWithUnknownFields(t *testing.T) {
+	measureTest(t)
 	c := `
 	[default]
 	unknown='TEST_ACCOUNT'
@@ -68,6 +70,7 @@ func TestLoadConfigFileWithUnknownFields(t *testing.T) {
 }
 
 func TestLoadConfigFileWithInvalidFieldValue(t *testing.T) {
+	measureTest(t)
 	c := `
 	[default]
 	accountname=42
@@ -79,6 +82,7 @@ func TestLoadConfigFileWithInvalidFieldValue(t *testing.T) {
 }
 
 func TestProfileConfig(t *testing.T) {
+	measureTest(t)
 	unencryptedKey, encryptedKey := random.GenerateRSAPrivateKeyEncrypted(t, "password")
 
 	c := fmt.Sprintf(`
@@ -199,6 +203,7 @@ func TestProfileConfig(t *testing.T) {
 }
 
 func Test_MergeConfig(t *testing.T) {
+	measureTest(t)
 	config1 := &gosnowflake.Config{
 		Account:                   "account1",
 		User:                      "user1",
@@ -306,6 +311,7 @@ func Test_MergeConfig(t *testing.T) {
 }
 
 func Test_ToAuthenticationType(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  gosnowflake.AuthType
@@ -347,6 +353,7 @@ func Test_ToAuthenticationType(t *testing.T) {
 }
 
 func Test_ToExtendedAuthenticatorType(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  gosnowflake.AuthType
@@ -390,6 +397,7 @@ func Test_ToExtendedAuthenticatorType(t *testing.T) {
 }
 
 func Test_Provider_toDriverLogLevel(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  DriverLogLevel

--- a/pkg/sdk/connections_gen_test.go
+++ b/pkg/sdk/connections_gen_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestConnections_Create(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 	defaultOpts := func() *CreateConnectionOptions {
 		return &CreateConnectionOptions{
@@ -64,6 +65,7 @@ func TestConnections_Create(t *testing.T) {
 }
 
 func TestConnections_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 	defaultOpts := func() *AlterConnectionOptions {
 		return &AlterConnectionOptions{
@@ -148,6 +150,7 @@ func TestConnections_Alter(t *testing.T) {
 }
 
 func TestConnections_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomAccountObjectIdentifier()
 	defaultOpts := func() *DropConnectionOptions {
 		return &DropConnectionOptions{
@@ -178,6 +181,7 @@ func TestConnections_Drop(t *testing.T) {
 }
 
 func TestConnections_Show(t *testing.T) {
+	measureTest(t)
 	defaultOpts := func() *ShowConnectionOptions {
 		return &ShowConnectionOptions{}
 	}

--- a/pkg/sdk/cortex_search_services_gen_test.go
+++ b/pkg/sdk/cortex_search_services_gen_test.go
@@ -3,6 +3,7 @@ package sdk
 import "testing"
 
 func TestCortexSearchServices_Create(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	// Minimal valid CreateCortexSearchServiceOptions
@@ -72,6 +73,7 @@ func TestCortexSearchServices_Create(t *testing.T) {
 }
 
 func TestCortexSearchServices_Alter(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	// Minimal valid AlterCortexSearchServiceOptions
@@ -125,6 +127,7 @@ func TestCortexSearchServices_Alter(t *testing.T) {
 }
 
 func TestCortexSearchServices_Show(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	// Minimal valid ShowCortexSearchServiceOptions
@@ -199,6 +202,7 @@ func TestCortexSearchServices_Show(t *testing.T) {
 }
 
 func TestCortexSearchServices_Describe(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	// Minimal valid DescribeCortexSearchServiceOptions
@@ -226,6 +230,7 @@ func TestCortexSearchServices_Describe(t *testing.T) {
 }
 
 func TestCortexSearchServices_Drop(t *testing.T) {
+	measureTest(t)
 	id := randomSchemaObjectIdentifier()
 
 	// Minimal valid DropCortexSearchServiceOptions

--- a/pkg/sdk/data_metric_function_references_gen_test.go
+++ b/pkg/sdk/data_metric_function_references_gen_test.go
@@ -3,6 +3,7 @@ package sdk
 import "testing"
 
 func TestDataMetricFunctionReferences_GetForEntity(t *testing.T) {
+	measureTest(t)
 	t.Run("validation: nil options", func(t *testing.T) {
 		var opts *GetForEntityDataMetricFunctionReferenceOptions
 		assertOptsInvalidJoinedErrors(t, opts, ErrNilOptions)

--- a/pkg/sdk/data_types_deprecated_test.go
+++ b/pkg/sdk/data_types_deprecated_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestIsStringType(t *testing.T) {
+	measureTest(t)
 	type test struct {
 		input string
 		want  bool

--- a/pkg/sdk/database_role_test.go
+++ b/pkg/sdk/database_role_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestDatabaseRoleCreate(t *testing.T) {
+	measureTest(t)
 	id := randomDatabaseObjectIdentifier()
 
 	defaultOpts := func() *createDatabaseRoleOptions {

--- a/pkg/sdk/setup_test.go
+++ b/pkg/sdk/setup_test.go
@@ -9,9 +9,23 @@ import (
 
 var testMeasurements = measurement.NewTestMeasurements()
 
-func measureTest(t *testing.T) {
+type T struct {
+	*testing.T
+}
+
+// TODO: Proposal for handling sub-testing without the need to call measureTest in them (check accounts_test.go to see how it could look like)
+// in this case we could call other function e.g. t := ourTest(tt), because we could use it later for other purposes and inside we would call measureTest anyway
+func (t *T) Run(name string, test func(t *T)) {
+	t.T.Run(name, func(tt *testing.T) {
+		measureTest(tt)
+		test(&T{tt})
+	})
+}
+
+func measureTest(t *testing.T) *T {
 	t.Helper()
 	measurement.MeasureTestTime(testMeasurements, t)
+	return &T{t}
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/sdk/setup_test.go
+++ b/pkg/sdk/setup_test.go
@@ -1,0 +1,21 @@
+package sdk
+
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/measurement"
+	"os"
+	"testing"
+	"time"
+)
+
+var testMeasurements = measurement.NewTestMeasurements()
+
+func measureTest(t *testing.T) {
+	t.Helper()
+	measurement.MeasureTestTime(testMeasurements, t)
+}
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	measurement.PrintMeasurementSummary(testMeasurements, time.Nanosecond)
+	os.Exit(code)
+}

--- a/pkg/sdk/testint/alerts_integration_test.go
+++ b/pkg/sdk/testint/alerts_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestInt_AlertsShow(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
@@ -22,12 +23,14 @@ func TestInt_AlertsShow(t *testing.T) {
 	t.Cleanup(alert2Cleanup)
 
 	t.Run("without show options", func(t *testing.T) {
+		measureTest(t)
 		alerts, err := client.Alerts.Show(ctx, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(alerts))
 	})
 
 	t.Run("with show options", func(t *testing.T) {
+		measureTest(t)
 		showOptions := &sdk.ShowAlertOptions{
 			In: &sdk.In{
 				Schema: testClientHelper().Ids.SchemaId(),
@@ -41,6 +44,7 @@ func TestInt_AlertsShow(t *testing.T) {
 	})
 
 	t.Run("with show options and like", func(t *testing.T) {
+		measureTest(t)
 		showOptions := &sdk.ShowAlertOptions{
 			Like: &sdk.Like{
 				Pattern: sdk.String(alertTest.Name),
@@ -56,6 +60,7 @@ func TestInt_AlertsShow(t *testing.T) {
 	})
 
 	t.Run("when searching a non-existent alert", func(t *testing.T) {
+		measureTest(t)
 		showOptions := &sdk.ShowAlertOptions{
 			Like: &sdk.Like{
 				Pattern: sdk.String("non-existent"),
@@ -67,6 +72,7 @@ func TestInt_AlertsShow(t *testing.T) {
 	})
 
 	t.Run("when limiting the number of results", func(t *testing.T) {
+		measureTest(t)
 		showOptions := &sdk.ShowAlertOptions{
 			In: &sdk.In{
 				Schema: testClientHelper().Ids.SchemaId(),
@@ -80,10 +86,12 @@ func TestInt_AlertsShow(t *testing.T) {
 }
 
 func TestInt_AlertCreate(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
 	t.Run("test complete case", func(t *testing.T) {
+		measureTest(t)
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		name := id.Name()
 		schedule := "USING CRON * * * * TUE,THU UTC"
@@ -120,6 +128,7 @@ func TestInt_AlertCreate(t *testing.T) {
 	})
 
 	t.Run("test if_not_exists", func(t *testing.T) {
+		measureTest(t)
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		name := id.Name()
 		schedule := "USING CRON * * * * TUE,THU UTC"
@@ -156,6 +165,7 @@ func TestInt_AlertCreate(t *testing.T) {
 	})
 
 	t.Run("test no options", func(t *testing.T) {
+		measureTest(t)
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		name := id.Name()
 		schedule := "USING CRON * * * * TUE,THU UTC"
@@ -186,6 +196,7 @@ func TestInt_AlertCreate(t *testing.T) {
 	})
 
 	t.Run("test multiline action", func(t *testing.T) {
+		measureTest(t)
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		name := id.Name()
 		schedule := "USING CRON * * * * TUE,THU UTC"
@@ -225,6 +236,7 @@ func TestInt_AlertCreate(t *testing.T) {
 }
 
 func TestInt_AlertDescribe(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
@@ -232,22 +244,26 @@ func TestInt_AlertDescribe(t *testing.T) {
 	t.Cleanup(alertCleanup)
 
 	t.Run("when alert exists", func(t *testing.T) {
+		measureTest(t)
 		alertDetails, err := client.Alerts.Describe(ctx, alert.ID())
 		require.NoError(t, err)
 		assert.Equal(t, alert.Name, alertDetails.Name)
 	})
 
 	t.Run("when alert does not exist", func(t *testing.T) {
+		measureTest(t)
 		_, err := client.Alerts.Describe(ctx, NonExistingSchemaObjectIdentifier)
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
 }
 
 func TestInt_AlertAlter(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
 	t.Run("when setting and unsetting a value", func(t *testing.T) {
+		measureTest(t)
 		alert, alertCleanup := testClientHelper().Alert.CreateAlert(t)
 		t.Cleanup(alertCleanup)
 		newSchedule := "USING CRON * * * * TUE,FRI GMT"
@@ -274,6 +290,7 @@ func TestInt_AlertAlter(t *testing.T) {
 	})
 
 	t.Run("when modifying condition and action", func(t *testing.T) {
+		measureTest(t)
 		alert, alertCleanup := testClientHelper().Alert.CreateAlert(t)
 		t.Cleanup(alertCleanup)
 		newCondition := "select * from DUAL where false"
@@ -318,6 +335,7 @@ func TestInt_AlertAlter(t *testing.T) {
 	})
 
 	t.Run("resume and then suspend", func(t *testing.T) {
+		measureTest(t)
 		alert, alertCleanup := testClientHelper().Alert.CreateAlert(t)
 		t.Cleanup(alertCleanup)
 
@@ -360,10 +378,12 @@ func TestInt_AlertAlter(t *testing.T) {
 }
 
 func TestInt_AlertDrop(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
 	t.Run("when alert exists", func(t *testing.T) {
+		measureTest(t)
 		alert, _ := testClientHelper().Alert.CreateAlert(t)
 		id := alert.ID()
 		err := client.Alerts.Drop(ctx, id, &sdk.DropAlertOptions{})
@@ -373,12 +393,14 @@ func TestInt_AlertDrop(t *testing.T) {
 	})
 
 	t.Run("when alert does not exist", func(t *testing.T) {
+		measureTest(t)
 		err := client.Alerts.Drop(ctx, NonExistingSchemaObjectIdentifier, &sdk.DropAlertOptions{})
 		assert.ErrorIs(t, err, sdk.ErrObjectNotExistOrAuthorized)
 	})
 }
 
 func TestInt_AlertsShowByID(t *testing.T) {
+	measureTest(t)
 	client := testClient(t)
 	ctx := testContext(t)
 
@@ -404,6 +426,7 @@ func TestInt_AlertsShowByID(t *testing.T) {
 	}
 
 	t.Run("show by id - same name in different schemas", func(t *testing.T) {
+		measureTest(t)
 		schema, schemaCleanup := testClientHelper().Schema.CreateSchema(t)
 		t.Cleanup(schemaCleanup)
 
@@ -423,6 +446,7 @@ func TestInt_AlertsShowByID(t *testing.T) {
 	})
 
 	t.Run("show by id: check fields", func(t *testing.T) {
+		measureTest(t)
 		id := testClientHelper().Ids.RandomSchemaObjectIdentifier()
 		createAlertHandle(t, id)
 

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/measurement"
 	"log"
 	"os"
 	"testing"
@@ -33,8 +34,16 @@ var (
 
 var itc integrationTestContext
 
+var testMeasurements = measurement.NewTestMeasurements()
+
+func measureTest(t *testing.T) {
+	t.Helper()
+	measurement.MeasureTestTime(testMeasurements, t)
+}
+
 func TestMain(m *testing.M) {
 	exitVal := execute(m)
+	measurement.PrintMeasurementSummary(testMeasurements, time.Millisecond)
 	os.Exit(exitVal)
 }
 
@@ -43,6 +52,7 @@ func execute(m *testing.M) int {
 	setup()
 	exitVal := m.Run()
 	cleanup()
+	//measurement.PrintMeasurementSummary(measurements)
 	return exitVal
 }
 


### PR DESCRIPTION
## Changes
- Add a set of tools to measure test times and print the summary at the end

## Tests
- The solution was already tested on unit and integration tests and seems to be working correctly. The only limitation is that sub-tests are separated by `/` sign which shouldn't be used in any test name (I checked that none of our test is using it, so we should be fine).

## Next steps
- Adjust all the tests to include the `measureTest` function at the start of one of them (we can agree in which cases we would like to skip measuring sub-tests, e.g., in the case of unit tests, which are really fast).

## References
Alternatives considered:
- [Using testify suite package](https://github.com/stretchr/testify?tab=readme-ov-file#suite-package)
- [Using custom code, similar to the approach in the grpc-go codebase (similar to testify suite package, but without any dependency)](https://github.com/grpc/grpc-go/blob/master/internal/grpctest/grpctest.go#L104)