### PR TITLE
chore: Release workflow adjustments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
+    tags: # Trigger on new tags that follow semantic versioning with `v` prefix (supports any postfix, e.g. `-rc1`)
+      - 'v[0-9]+.[0-9]+.[0-9]+(-.+)?'
 
 jobs:
   release-please:


### PR DESCRIPTION
## Changes
- Adjust tag event regex for release workflow (now, it's only triggered when the tag follows semantic versioning with possible postfixes; prefixes were skipped as we only thought of using postfixes in our versioning strategy).