### PR TITLE
chore: Allow only one concurrent job for tests on the given branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 # Run secret-dependent integration tests only after /ok-to-test approval
 name: Tests
 
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   repository_dispatch:
     types: [ ok-to-test-command ]


### PR DESCRIPTION
Allow only one concurrent tests job for the given PR.
Cancel the in progress one if new commits exist.