### PR TITLE
chore: Masking random values

### DIFF
--- a/pkg/acceptance/helpers/account_client.go
+++ b/pkg/acceptance/helpers/account_client.go
@@ -53,7 +53,7 @@ func (c *AccountClient) GetAccountIdentifier(t *testing.T) sdk.AccountIdentifier
 
 func (c *AccountClient) Create(t *testing.T) (*sdk.Account, func()) {
 	t.Helper()
-	id := c.ids.SensitiveRandomAccountObjectIdentifier()
+	id := c.ids.RandomSensitiveAccountObjectIdentifier()
 	name := random.AdminName()
 	email := random.Email()
 	privateKey := random.GenerateRSAPrivateKey(t)
@@ -122,7 +122,7 @@ func (c *AccountClient) Show(t *testing.T, id sdk.AccountObjectIdentifier) (*sdk
 
 func (c *AccountClient) CreateAndLogIn(t *testing.T) (*sdk.Account, *sdk.Client, func()) {
 	t.Helper()
-	id := c.ids.SensitiveRandomAccountObjectIdentifier()
+	id := c.ids.RandomSensitiveAccountObjectIdentifier()
 	name := random.AdminName()
 	privateKey := random.GenerateRSAPrivateKey(t)
 	publicKey, _ := random.GenerateRSAPublicKeyFromPrivateKey(t, privateKey)

--- a/pkg/acceptance/helpers/account_client.go
+++ b/pkg/acceptance/helpers/account_client.go
@@ -54,7 +54,7 @@ func (c *AccountClient) GetAccountIdentifier(t *testing.T) sdk.AccountIdentifier
 func (c *AccountClient) Create(t *testing.T) (*sdk.Account, func()) {
 	t.Helper()
 	id := c.ids.RandomAccountObjectIdentifier()
-	name := c.ids.Alpha()
+	name := random.AdminName()
 	email := random.Email()
 	privateKey := random.GenerateRSAPrivateKey(t)
 	publicKey, _ := random.GenerateRSAPublicKeyFromPrivateKey(t, privateKey)
@@ -123,7 +123,7 @@ func (c *AccountClient) Show(t *testing.T, id sdk.AccountObjectIdentifier) (*sdk
 func (c *AccountClient) CreateAndLogIn(t *testing.T) (*sdk.Account, *sdk.Client, func()) {
 	t.Helper()
 	id := c.ids.RandomAccountObjectIdentifier()
-	name := c.ids.Alpha()
+	name := random.AdminName()
 	privateKey := random.GenerateRSAPrivateKey(t)
 	publicKey, _ := random.GenerateRSAPublicKeyFromPrivateKey(t, privateKey)
 	email := random.Email()

--- a/pkg/acceptance/helpers/account_client.go
+++ b/pkg/acceptance/helpers/account_client.go
@@ -53,7 +53,7 @@ func (c *AccountClient) GetAccountIdentifier(t *testing.T) sdk.AccountIdentifier
 
 func (c *AccountClient) Create(t *testing.T) (*sdk.Account, func()) {
 	t.Helper()
-	id := c.ids.RandomAccountObjectIdentifier()
+	id := c.ids.SensitiveRandomAccountObjectIdentifier()
 	name := random.AdminName()
 	email := random.Email()
 	privateKey := random.GenerateRSAPrivateKey(t)
@@ -122,7 +122,7 @@ func (c *AccountClient) Show(t *testing.T, id sdk.AccountObjectIdentifier) (*sdk
 
 func (c *AccountClient) CreateAndLogIn(t *testing.T) (*sdk.Account, *sdk.Client, func()) {
 	t.Helper()
-	id := c.ids.RandomAccountObjectIdentifier()
+	id := c.ids.SensitiveRandomAccountObjectIdentifier()
 	name := random.AdminName()
 	privateKey := random.GenerateRSAPrivateKey(t)
 	publicKey, _ := random.GenerateRSAPublicKeyFromPrivateKey(t, privateKey)

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -43,6 +43,10 @@ func (c *IdsGenerator) RandomAccountObjectIdentifier() sdk.AccountObjectIdentifi
 	return sdk.NewAccountObjectIdentifier(c.Alpha())
 }
 
+func (c *IdsGenerator) SensitiveRandomAccountObjectIdentifier() sdk.AccountObjectIdentifier {
+	return sdk.NewAccountObjectIdentifier(random.SensitiveAlphanumeric())
+}
+
 func (c *IdsGenerator) RandomAccountObjectIdentifierWithPrefix(prefix string) sdk.AccountObjectIdentifier {
 	return sdk.NewAccountObjectIdentifier(c.AlphaWithPrefix(prefix))
 }

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -44,7 +44,7 @@ func (c *IdsGenerator) RandomAccountObjectIdentifier() sdk.AccountObjectIdentifi
 }
 
 func (c *IdsGenerator) RandomSensitiveAccountObjectIdentifier() sdk.AccountObjectIdentifier {
-	return sdk.NewAccountObjectIdentifier(random.SensitiveAlphanumeric())
+	return c.RandomAccountObjectIdentifierWithPrefix(random.SensitiveAlphanumeric())
 }
 
 func (c *IdsGenerator) RandomAccountObjectIdentifierWithPrefix(prefix string) sdk.AccountObjectIdentifier {

--- a/pkg/acceptance/helpers/ids_generator.go
+++ b/pkg/acceptance/helpers/ids_generator.go
@@ -43,7 +43,7 @@ func (c *IdsGenerator) RandomAccountObjectIdentifier() sdk.AccountObjectIdentifi
 	return sdk.NewAccountObjectIdentifier(c.Alpha())
 }
 
-func (c *IdsGenerator) SensitiveRandomAccountObjectIdentifier() sdk.AccountObjectIdentifier {
+func (c *IdsGenerator) RandomSensitiveAccountObjectIdentifier() sdk.AccountObjectIdentifier {
 	return sdk.NewAccountObjectIdentifier(random.SensitiveAlphanumeric())
 }
 

--- a/pkg/acceptance/helpers/random/random_helpers.go
+++ b/pkg/acceptance/helpers/random/random_helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // generatedRandomValue is used to mask random values in GitHub Action logs.
-// It always starts with a letter and contains only letters and numbers.
+// It always starts with a letter and contains only letters.
 var generatedRandomValue string
 
 func init() {
@@ -36,7 +36,7 @@ func Comment() string {
 // 090088 (22000): ADMIN_NAME can only contain letters, numbers and underscores.
 // 090089 (22000): ADMIN_NAME must start with a letter.
 func AdminName() string {
-	return SensitiveAlphanumeric()
+	return SensitiveAlpha()
 }
 
 func Email() string {
@@ -57,6 +57,12 @@ func SensitiveString() string {
 // The string returned by SensitiveAlphanumeric always starts with a letter and contains only letters and numbers.
 func SensitiveAlphanumeric() string {
 	return generatedRandomValue + AlphanumericN(10)
+}
+
+// SensitiveAlpha returns a random string prefixed with a generated random value that is masked in GitHub Action logs.
+// The string returned by SensitiveAlphanumeric always starts with a letter and contains only letters.
+func SensitiveAlpha() string {
+	return generatedRandomValue + AlphaN(10)
 }
 
 func Bool() bool {

--- a/pkg/acceptance/helpers/random/random_helpers.go
+++ b/pkg/acceptance/helpers/random/random_helpers.go
@@ -1,9 +1,10 @@
 package random
 
 import (
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"log"
 	"os"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hashicorp/go-uuid"

--- a/pkg/acceptance/helpers/random/random_helpers.go
+++ b/pkg/acceptance/helpers/random/random_helpers.go
@@ -31,6 +31,7 @@ func Comment() string {
 	return gofakeit.Sentence(10)
 }
 
+// TODO: Will be removed and replaced with testClient.Random.Secret()
 func Password() string {
 	return generatedRandomValue + StringN(30)
 }

--- a/pkg/acceptance/helpers/random/random_helpers.go
+++ b/pkg/acceptance/helpers/random/random_helpers.go
@@ -1,16 +1,16 @@
 package random
 
 import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 	"log"
 	"os"
-	"strings"
-
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hashicorp/go-uuid"
 )
 
+// generatedRandomValue is used to mask random values in GitHub Action logs.
+// It always starts with a letter and contains only letters and numbers.
 var generatedRandomValue string
 
 func init() {
@@ -31,16 +31,31 @@ func Comment() string {
 	return gofakeit.Sentence(10)
 }
 
-// TODO: Will be removed and replaced with testClient.Random.Secret()
-func Password() string {
-	return generatedRandomValue + StringN(30)
-}
-
 // AdminName returns admin name acceptable by Snowflake:
 // 090088 (22000): ADMIN_NAME can only contain letters, numbers and underscores.
 // 090089 (22000): ADMIN_NAME must start with a letter.
 func AdminName() string {
-	return strings.ToUpper(AlphaN(1) + AlphanumericN(11))
+	return SensitiveAlphanumeric()
+}
+
+func Email() string {
+	return SensitiveAlphanumeric() + gofakeit.Email()
+}
+
+func Password() string {
+	return SensitiveString()
+}
+
+// SensitiveString returns a random string prefixed with a generated random value that is masked in GitHub Action logs.
+// The string returned by SensitiveString always starts with a letter and contains only letters, numbers, and symbols.
+func SensitiveString() string {
+	return generatedRandomValue + StringN(30)
+}
+
+// SensitiveAlphanumeric returns a random string prefixed with a generated random value that is masked in GitHub Action logs.
+// The string returned by SensitiveAlphanumeric always starts with a letter and contains only letters and numbers.
+func SensitiveAlphanumeric() string {
+	return generatedRandomValue + AlphanumericN(30)
 }
 
 func Bool() bool {
@@ -65,10 +80,6 @@ func AlphaN(num int) string {
 
 func AlphaLowerN(num int) string {
 	return gofakeit.Password(true, false, false, false, false, num)
-}
-
-func Email() string {
-	return gofakeit.Email()
 }
 
 func Bytes() []byte {

--- a/pkg/acceptance/helpers/random/random_helpers.go
+++ b/pkg/acceptance/helpers/random/random_helpers.go
@@ -50,13 +50,13 @@ func Password() string {
 // SensitiveString returns a random string prefixed with a generated random value that is masked in GitHub Action logs.
 // The string returned by SensitiveString always starts with a letter and contains only letters, numbers, and symbols.
 func SensitiveString() string {
-	return generatedRandomValue + StringN(30)
+	return generatedRandomValue + StringN(10)
 }
 
 // SensitiveAlphanumeric returns a random string prefixed with a generated random value that is masked in GitHub Action logs.
 // The string returned by SensitiveAlphanumeric always starts with a letter and contains only letters and numbers.
 func SensitiveAlphanumeric() string {
-	return generatedRandomValue + AlphanumericN(30)
+	return generatedRandomValue + AlphanumericN(10)
 }
 
 func Bool() bool {

--- a/pkg/resources/account_acceptance_test.go
+++ b/pkg/resources/account_acceptance_test.go
@@ -245,7 +245,7 @@ func TestAcc_Account_Rename(t *testing.T) {
 	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 
 	newId := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
-	newAccountId := sdk.NewAccountIdentifier(organizationName, newId)
+	newAccountId := sdk.NewAccountIdentifier(organizationName, newId.Name())
 
 	email := random.Email()
 	name := random.AdminName()
@@ -254,7 +254,7 @@ func TestAcc_Account_Rename(t *testing.T) {
 	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
-	newConfigModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, newId).
+	newConfigModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, newId.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 
@@ -286,12 +286,12 @@ func TestAcc_Account_Rename(t *testing.T) {
 				Config: config.FromModels(t, newConfigModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, newConfigModel.ResourceReference()).
-						HasNameString(newId).
+						HasNameString(newId.Name()).
 						HasFullyQualifiedNameString(newAccountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService),
 					resourceshowoutputassert.AccountShowOutput(t, newConfigModel.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(newId),
+						HasAccountName(newId.Name()),
 				),
 			},
 		},

--- a/pkg/resources/account_acceptance_test.go
+++ b/pkg/resources/account_acceptance_test.go
@@ -32,14 +32,14 @@ func TestAcc_Account_Minimal(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.SensitiveString()
-	accountId := sdk.NewAccountIdentifier(organizationName, id)
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
+	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
 	region := acc.TestClient().Context.CurrentRegion(t)
 
-	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminRsaPublicKey(key)
 
 	resource.Test(t, resource.TestCase{
@@ -53,7 +53,7 @@ func TestAcc_Account_Minimal(t *testing.T) {
 				Config: config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminNameString(name).
 						HasAdminRsaPublicKeyString(key).
@@ -69,7 +69,7 @@ func TestAcc_Account_Minimal(t *testing.T) {
 						HasGracePeriodInDaysString("3"),
 					resourceshowoutputassert.AccountShowOutput(t, configModel.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasSnowflakeRegion(region).
 						HasRegionGroup("").
 						HasEdition(sdk.EditionStandard).
@@ -105,7 +105,7 @@ func TestAcc_Account_Minimal(t *testing.T) {
 				ImportState:  true,
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedAccountResource(t, helpers.EncodeResourceIdentifier(accountId)).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasNoAdminName().
 						HasNoAdminRsaPublicKey().
@@ -131,17 +131,17 @@ func TestAcc_Account_Complete(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.SensitiveString()
-	accountId := sdk.NewAccountIdentifier(organizationName, id)
-	firstName := acc.TestClient().Ids.Alpha()
-	lastName := acc.TestClient().Ids.Alpha()
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
+	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
+	firstName := random.AlphaN(30)
+	lastName := random.AlphaN(30)
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
 	region := acc.TestClient().Context.CurrentRegion(t)
 	comment := random.Comment()
 
-	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypePerson).
 		WithAdminRsaPublicKey(key).
 		WithFirstName(firstName).
@@ -163,8 +163,8 @@ func TestAcc_Account_Complete(t *testing.T) {
 				Config: config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(id).
-						HasFullyQualifiedNameString(sdk.NewAccountIdentifier(organizationName, id).FullyQualifiedName()).
+						HasNameString(id.Name()).
+						HasFullyQualifiedNameString(sdk.NewAccountIdentifier(organizationName, id.Name()).FullyQualifiedName()).
 						HasAdminNameString(name).
 						HasAdminRsaPublicKeyString(key).
 						HasAdminUserType(sdk.UserTypePerson).
@@ -179,7 +179,7 @@ func TestAcc_Account_Complete(t *testing.T) {
 						HasGracePeriodInDaysString("3"),
 					resourceshowoutputassert.AccountShowOutput(t, configModel.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasSnowflakeRegion(region).
 						HasRegionGroup("").
 						HasEdition(sdk.EditionStandard).
@@ -215,8 +215,8 @@ func TestAcc_Account_Complete(t *testing.T) {
 				ImportState:  true,
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedAccountResource(t, helpers.EncodeResourceIdentifier(accountId)).
-						HasNameString(id).
-						HasFullyQualifiedNameString(sdk.NewAccountIdentifier(organizationName, id).FullyQualifiedName()).
+						HasNameString(id.Name()).
+						HasFullyQualifiedNameString(sdk.NewAccountIdentifier(organizationName, id.Name()).FullyQualifiedName()).
 						HasNoAdminName().
 						HasNoAdminRsaPublicKey().
 						HasNoEmail().
@@ -241,8 +241,8 @@ func TestAcc_Account_Rename(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.SensitiveString()
-	accountId := sdk.NewAccountIdentifier(organizationName, id)
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
+	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 
 	newId := random.SensitiveString()
 	newAccountId := sdk.NewAccountIdentifier(organizationName, newId)
@@ -251,7 +251,7 @@ func TestAcc_Account_Rename(t *testing.T) {
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
 
-	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 	newConfigModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, newId).
@@ -269,12 +269,12 @@ func TestAcc_Account_Rename(t *testing.T) {
 				Config: config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService),
 					resourceshowoutputassert.AccountShowOutput(t, configModel.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id),
+						HasAccountName(id.Name()),
 				),
 			},
 			{
@@ -303,24 +303,24 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.SensitiveString()
-	accountId := sdk.NewAccountIdentifier(organizationName, id)
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
+	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
 
-	configModelWithOrgAdminTrue := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModelWithOrgAdminTrue := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key).
 		WithIsOrgAdmin(r.BooleanTrue)
 
-	configModelWithOrgAdminFalse := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModelWithOrgAdminFalse := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key).
 		WithIsOrgAdmin(r.BooleanFalse)
 
-	configModelWithoutOrgAdmin := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModelWithoutOrgAdmin := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 
@@ -336,13 +336,13 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 				Config: config.FromModels(t, configModelWithOrgAdminTrue),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModelWithOrgAdminTrue.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService).
 						HasIsOrgAdminString(r.BooleanTrue),
 					resourceshowoutputassert.AccountShowOutput(t, configModelWithOrgAdminTrue.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasIsOrgAdmin(true),
 				),
 			},
@@ -356,13 +356,13 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 				Config: config.FromModels(t, configModelWithOrgAdminFalse),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModelWithOrgAdminFalse.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService).
 						HasIsOrgAdminString(r.BooleanFalse),
 					resourceshowoutputassert.AccountShowOutput(t, configModelWithOrgAdminFalse.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasIsOrgAdmin(false),
 				),
 			},
@@ -376,13 +376,13 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 				Config: config.FromModels(t, configModelWithoutOrgAdmin),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModelWithoutOrgAdmin.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService).
 						HasIsOrgAdminString(r.BooleanDefault),
 					resourceshowoutputassert.AccountShowOutput(t, configModelWithoutOrgAdmin.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasIsOrgAdmin(false),
 				),
 			},
@@ -404,13 +404,13 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 				Config: config.FromModels(t, configModelWithoutOrgAdmin),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModelWithoutOrgAdmin.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminUserType(sdk.UserTypeService).
 						HasIsOrgAdminString(r.BooleanDefault),
 					resourceshowoutputassert.AccountShowOutput(t, configModelWithoutOrgAdmin.ResourceReference()).
 						HasOrganizationName(organizationName).
-						HasAccountName(id).
+						HasAccountName(id.Name()).
 						HasIsOrgAdmin(false),
 				),
 			},
@@ -423,29 +423,29 @@ func TestAcc_Account_IgnoreUpdateAfterCreationOnCertainFields(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.SensitiveString()
-	accountId := sdk.NewAccountIdentifier(organizationName, id)
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
+	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 
-	firstName := random.SensitiveAlphanumeric()
-	lastName := random.SensitiveAlphanumeric()
+	firstName := random.AlphaN(30)
+	lastName := random.AlphaN(30)
 	email := random.Email()
 	name := random.AdminName()
 	pass := random.Password()
 
-	newFirstName := random.SensitiveAlphanumeric()
-	newLastName := random.SensitiveAlphanumeric()
+	newFirstName := random.AlphaN(30)
+	newLastName := random.AlphaN(30)
 	newEmail := random.Email()
 	newName := random.AdminName()
 	newPass := random.Password()
 
-	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypePerson).
 		WithFirstName(firstName).
 		WithLastName(lastName).
 		WithMustChangePassword(r.BooleanTrue).
 		WithAdminPassword(pass)
 
-	newConfigModel := model.Account("test", newName, string(sdk.EditionStandard), newEmail, 3, id).
+	newConfigModel := model.Account("test", newName, string(sdk.EditionStandard), newEmail, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminPassword(newPass).
 		WithFirstName(newFirstName).
@@ -462,7 +462,7 @@ func TestAcc_Account_IgnoreUpdateAfterCreationOnCertainFields(t *testing.T) {
 				Config: config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminNameString(name).
 						HasAdminPasswordString(pass).
@@ -482,7 +482,7 @@ func TestAcc_Account_IgnoreUpdateAfterCreationOnCertainFields(t *testing.T) {
 				Config: config.FromModels(t, newConfigModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, newConfigModel.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasFullyQualifiedNameString(accountId.FullyQualifiedName()).
 						HasAdminNameString(name).
 						HasAdminPasswordString(pass).
@@ -501,7 +501,7 @@ func TestAcc_Account_TryToCreateWithoutOrgadmin(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
-	id := random.SensitiveString()
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
@@ -509,7 +509,7 @@ func TestAcc_Account_TryToCreateWithoutOrgadmin(t *testing.T) {
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 	t.Setenv(snowflakeenvs.Role, snowflakeroles.Accountadmin.Name())
 
-	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 
@@ -532,20 +532,20 @@ func TestAcc_Account_InvalidValues(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
-	id := random.SensitiveString()
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
 
-	configModelInvalidUserType := model.Account("test", name, string(sdk.EditionStandard), email, 3, id).
+	configModelInvalidUserType := model.Account("test", name, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserType("invalid_user_type").
 		WithAdminRsaPublicKey(key)
 
-	configModelInvalidAccountEdition := model.Account("test", name, "invalid_account_edition", email, 3, id).
+	configModelInvalidAccountEdition := model.Account("test", name, "invalid_account_edition", email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 
-	configModelInvalidGracePeriodInDays := model.Account("test", name, string(sdk.EditionStandard), email, 2, id).
+	configModelInvalidGracePeriodInDays := model.Account("test", name, string(sdk.EditionStandard), email, 2, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminRsaPublicKey(key)
 
@@ -576,16 +576,16 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
-	id := random.SensitiveString()
+	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
 	email := random.Email()
 	adminName := random.AdminName()
 	adminPassword := random.Password()
-	firstName := random.SensitiveAlphanumeric()
-	lastName := random.SensitiveAlphanumeric()
+	firstName := random.AlphaN(30)
+	lastName := random.AlphaN(30)
 	region := acc.TestClient().Context.CurrentRegion(t)
 	comment := random.Comment()
 
-	configModel := model.Account("test", adminName, string(sdk.EditionStandard), email, 3, id).
+	configModel := model.Account("test", adminName, string(sdk.EditionStandard), email, 3, id.Name()).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminPassword(adminPassword).
 		WithFirstName(firstName).
@@ -603,14 +603,14 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviderWithExactVersion("0.99.0"),
-				Config:            accountConfig_v0_99_0(id, adminName, adminPassword, email, sdk.EditionStandard, firstName, lastName, true, region, 3, comment),
+				Config:            accountConfig_v0_99_0(id.Name(), adminName, adminPassword, email, sdk.EditionStandard, firstName, lastName, true, region, 3, comment),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(id).
+						HasNameString(id.Name()).
 						HasAdminNameString(adminName).
 						HasAdminPasswordString(adminPassword).
 						HasEmailString(email).

--- a/pkg/resources/account_acceptance_test.go
+++ b/pkg/resources/account_acceptance_test.go
@@ -244,7 +244,7 @@ func TestAcc_Account_Rename(t *testing.T) {
 	id := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
 	accountId := sdk.NewAccountIdentifier(organizationName, id.Name())
 
-	newId := random.SensitiveString()
+	newId := acc.TestClient().Ids.RandomSensitiveAccountObjectIdentifier()
 	newAccountId := sdk.NewAccountIdentifier(organizationName, newId)
 
 	email := random.Email()

--- a/pkg/resources/account_acceptance_test.go
+++ b/pkg/resources/account_acceptance_test.go
@@ -32,7 +32,7 @@ func TestAcc_Account_Minimal(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.AdminName()
+	id := random.SensitiveString()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
 	email := random.Email()
 	name := random.AdminName()
@@ -131,7 +131,7 @@ func TestAcc_Account_Complete(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.AdminName()
+	id := random.SensitiveString()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
 	firstName := acc.TestClient().Ids.Alpha()
 	lastName := acc.TestClient().Ids.Alpha()
@@ -241,10 +241,10 @@ func TestAcc_Account_Rename(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.AdminName()
+	id := random.SensitiveString()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
 
-	newId := random.AdminName()
+	newId := random.SensitiveString()
 	newAccountId := sdk.NewAccountIdentifier(organizationName, newId)
 
 	email := random.Email()
@@ -303,7 +303,7 @@ func TestAcc_Account_IsOrgAdmin(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.AdminName()
+	id := random.SensitiveString()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
 
 	email := random.Email()
@@ -423,17 +423,17 @@ func TestAcc_Account_IgnoreUpdateAfterCreationOnCertainFields(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
 	organizationName := acc.TestClient().Context.CurrentAccountId(t).OrganizationName()
-	id := random.AdminName()
+	id := random.SensitiveString()
 	accountId := sdk.NewAccountIdentifier(organizationName, id)
 
-	firstName := random.AdminName()
-	lastName := random.AdminName()
+	firstName := random.SensitiveAlphanumeric()
+	lastName := random.SensitiveAlphanumeric()
 	email := random.Email()
 	name := random.AdminName()
 	pass := random.Password()
 
-	newFirstName := random.AdminName()
-	newLastName := random.AdminName()
+	newFirstName := random.SensitiveAlphanumeric()
+	newLastName := random.SensitiveAlphanumeric()
 	newEmail := random.Email()
 	newName := random.AdminName()
 	newPass := random.Password()
@@ -501,7 +501,7 @@ func TestAcc_Account_TryToCreateWithoutOrgadmin(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
-	id := random.AdminName()
+	id := random.SensitiveString()
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
@@ -532,7 +532,7 @@ func TestAcc_Account_InvalidValues(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
-	id := random.AdminName()
+	id := random.SensitiveString()
 	email := random.Email()
 	name := random.AdminName()
 	key, _ := random.GenerateRSAPublicKey(t)
@@ -580,8 +580,8 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 	name := random.AdminName()
 	adminName := random.AdminName()
 	adminPassword := random.Password()
-	firstName := random.AdminName()
-	lastName := random.AdminName()
+	firstName := random.SensitiveAlphanumeric()
+	lastName := random.SensitiveAlphanumeric()
 	region := acc.TestClient().Context.CurrentRegion(t)
 	comment := random.Comment()
 

--- a/pkg/resources/account_acceptance_test.go
+++ b/pkg/resources/account_acceptance_test.go
@@ -576,8 +576,8 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	_ = testenvs.GetOrSkipTest(t, testenvs.TestAccountCreate)
 
+	id := random.SensitiveString()
 	email := random.Email()
-	name := random.AdminName()
 	adminName := random.AdminName()
 	adminPassword := random.Password()
 	firstName := random.SensitiveAlphanumeric()
@@ -585,7 +585,7 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 	region := acc.TestClient().Context.CurrentRegion(t)
 	comment := random.Comment()
 
-	configModel := model.Account("test", adminName, string(sdk.EditionStandard), email, 3, name).
+	configModel := model.Account("test", adminName, string(sdk.EditionStandard), email, 3, id).
 		WithAdminUserTypeEnum(sdk.UserTypeService).
 		WithAdminPassword(adminPassword).
 		WithFirstName(firstName).
@@ -603,14 +603,14 @@ func TestAcc_Account_UpgradeFrom_v0_99_0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: acc.ExternalProviderWithExactVersion("0.99.0"),
-				Config:            accountConfig_v0_99_0(name, adminName, adminPassword, email, sdk.EditionStandard, firstName, lastName, true, region, 3, comment),
+				Config:            accountConfig_v0_99_0(id, adminName, adminPassword, email, sdk.EditionStandard, firstName, lastName, true, region, 3, comment),
 			},
 			{
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 				Config:                   config.FromModels(t, configModel),
 				Check: assertThat(t,
 					resourceassert.AccountResource(t, configModel.ResourceReference()).
-						HasNameString(name).
+						HasNameString(id).
 						HasAdminNameString(adminName).
 						HasAdminPasswordString(adminPassword).
 						HasEmailString(email).

--- a/pkg/resources/legacy_service_user_acceptance_test.go
+++ b/pkg/resources/legacy_service_user_acceptance_test.go
@@ -40,6 +40,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 	key1, _ := random.GenerateRSAPublicKey(t)
 	key2, _ := random.GenerateRSAPublicKey(t)
 
+	loginName := random.SensitiveAlphanumeric()
 	pass := random.Password()
 	newPass := random.Password()
 
@@ -49,7 +50,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 
 	userModelAllAttributes := model.LegacyServiceUser("w", id.Name()).
 		WithPassword(pass).
-		WithLoginName(id.Name() + "_login").
+		WithLoginName(loginName + "_login").
 		WithDisplayName("Display Name").
 		WithEmail("fake@email.com").
 		WithMustChangePassword("true").
@@ -158,7 +159,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 					resourceassert.LegacyServiceUserResource(t, userModelAllAttributes.ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(pass).
-						HasLoginNameString(fmt.Sprintf("%s_login", id.Name())).
+						HasLoginNameString(fmt.Sprintf("%s_login", loginName)).
 						HasDisplayNameString("Display Name").
 						HasEmailString("fake@email.com").
 						HasMustChangePassword(true).
@@ -177,12 +178,12 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: config.FromModels(t, userModelAllAttributesChanged(id.Name()+"_other_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_other_login")),
 				Check: assertThat(t,
-					resourceassert.LegacyServiceUserResource(t, userModelAllAttributesChanged(id.Name()+"_other_login").ResourceReference()).
+					resourceassert.LegacyServiceUserResource(t, userModelAllAttributesChanged(loginName+"_other_login").ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(newPass).
-						HasLoginNameString(fmt.Sprintf("%s_other_login", id.Name())).
+						HasLoginNameString(fmt.Sprintf("%s_other_login", loginName)).
 						HasDisplayNameString("New Display Name").
 						HasEmailString("fake@email.net").
 						HasMustChangePassword(false).
@@ -201,22 +202,22 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            userModelAllAttributesChanged(id.Name() + "_other_login").ResourceReference(),
+				ResourceName:            userModelAllAttributesChanged(loginName + "_other_login").ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password", "days_to_expiry", "mins_to_unlock", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedLegacyServiceUserResource(t, id.Name()).
 						HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-						HasLoginNameString(fmt.Sprintf("%s_OTHER_LOGIN", id.Name())),
+						HasLoginNameString(strings.ToUpper(fmt.Sprintf("%s_other_login", loginName))),
 				),
 			},
 			// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
 			{
 				PreConfig: func() {
-					acc.TestClient().User.SetLoginName(t, id, id.Name()+"_different_login")
+					acc.TestClient().User.SetLoginName(t, id, loginName+"_different_login")
 				},
-				Config: config.FromModels(t, userModelAllAttributesChanged(id.Name()+"_different_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_different_login")),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/pkg/resources/legacy_service_user_acceptance_test.go
+++ b/pkg/resources/legacy_service_user_acceptance_test.go
@@ -41,6 +41,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 	key2, _ := random.GenerateRSAPublicKey(t)
 
 	loginName := random.SensitiveAlphanumeric()
+	newLoginName := random.SensitiveAlphanumeric()
 	pass := random.Password()
 	newPass := random.Password()
 
@@ -50,7 +51,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 
 	userModelAllAttributes := model.LegacyServiceUser("w", id.Name()).
 		WithPassword(pass).
-		WithLoginName(loginName + "_login").
+		WithLoginName(loginName).
 		WithDisplayName("Display Name").
 		WithEmail("fake@email.com").
 		WithMustChangePassword("true").
@@ -159,7 +160,7 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 					resourceassert.LegacyServiceUserResource(t, userModelAllAttributes.ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(pass).
-						HasLoginNameString(fmt.Sprintf("%s_login", loginName)).
+						HasLoginNameString(loginName).
 						HasDisplayNameString("Display Name").
 						HasEmailString("fake@email.com").
 						HasMustChangePassword(true).
@@ -178,12 +179,12 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_other_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(newLoginName)),
 				Check: assertThat(t,
-					resourceassert.LegacyServiceUserResource(t, userModelAllAttributesChanged(loginName+"_other_login").ResourceReference()).
+					resourceassert.LegacyServiceUserResource(t, userModelAllAttributesChanged(newLoginName).ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(newPass).
-						HasLoginNameString(fmt.Sprintf("%s_other_login", loginName)).
+						HasLoginNameString(newLoginName).
 						HasDisplayNameString("New Display Name").
 						HasEmailString("fake@email.net").
 						HasMustChangePassword(false).
@@ -202,22 +203,22 @@ func TestAcc_LegacyServiceUser_BasicFlows(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            userModelAllAttributesChanged(loginName + "_other_login").ResourceReference(),
+				ResourceName:            userModelAllAttributesChanged(newLoginName).ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password", "days_to_expiry", "mins_to_unlock", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedLegacyServiceUserResource(t, id.Name()).
 						HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-						HasLoginNameString(strings.ToUpper(fmt.Sprintf("%s_other_login", loginName))),
+						HasLoginNameString(strings.ToUpper(newLoginName)),
 				),
 			},
 			// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
 			{
 				PreConfig: func() {
-					acc.TestClient().User.SetLoginName(t, id, loginName+"_different_login")
+					acc.TestClient().User.SetLoginName(t, id, loginName)
 				},
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_different_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName)),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/pkg/resources/managed_account_acceptance_test.go
+++ b/pkg/resources/managed_account_acceptance_test.go
@@ -4,8 +4,9 @@ package resources_test
 
 import (
 	"fmt"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"testing"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 

--- a/pkg/resources/managed_account_acceptance_test.go
+++ b/pkg/resources/managed_account_acceptance_test.go
@@ -4,6 +4,7 @@ package resources_test
 
 import (
 	"fmt"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"testing"
 
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
@@ -27,8 +28,8 @@ func TestAcc_ManagedAccount(t *testing.T) {
 	testenvs.SkipTestIfSet(t, testenvs.SkipManagedAccountTest, "error: 090337 (23001): Number of managed accounts allowed exceeded the limit. Please contact Snowflake support")
 
 	id := acc.TestClient().Ids.RandomAccountObjectIdentifier()
-	adminName := acc.TestClient().Ids.Alpha()
-	adminPass := acc.TestClient().Ids.AlphaWithPrefix("A1")
+	adminName := random.AdminName()
+	adminPass := random.Password()
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
@@ -68,8 +69,8 @@ func TestAcc_ManagedAccount_HandleShowOutputChanges_BCR_2024_08(t *testing.T) {
 	testenvs.SkipTestIfSet(t, testenvs.SkipManagedAccountTest, "error: 090337 (23001): Number of managed accounts allowed exceeded the limit. Please contact Snowflake support")
 
 	id := acc.TestClient().Ids.RandomAccountObjectIdentifier()
-	adminName := acc.TestClient().Ids.Alpha()
-	adminPass := acc.TestClient().Ids.AlphaWithPrefix("ABC_abc_123!!!")
+	adminName := random.AdminName()
+	adminPass := random.Password()
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,

--- a/pkg/resources/service_user_acceptance_test.go
+++ b/pkg/resources/service_user_acceptance_test.go
@@ -35,6 +35,7 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 	id2 := acc.TestClient().Ids.RandomAccountObjectIdentifier()
 
 	loginName := random.SensitiveAlphanumeric()
+	newLoginName := random.SensitiveAlphanumeric()
 
 	comment := random.Comment()
 	newComment := random.Comment()
@@ -47,7 +48,7 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 		WithComment(newComment)
 
 	userModelAllAttributes := model.ServiceUser("w", id.Name()).
-		WithLoginName(loginName + "_login").
+		WithLoginName(loginName).
 		WithDisplayName("Display Name").
 		WithEmail("fake@email.com").
 		WithDisabled("false").
@@ -149,7 +150,7 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 				Check: assertThat(t,
 					resourceassert.ServiceUserResource(t, userModelAllAttributes.ResourceReference()).
 						HasNameString(id.Name()).
-						HasLoginNameString(fmt.Sprintf("%s_login", loginName)).
+						HasLoginNameString(loginName).
 						HasDisplayNameString("Display Name").
 						HasEmailString("fake@email.com").
 						HasDisabled(false).
@@ -167,11 +168,11 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_other_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(newLoginName)),
 				Check: assertThat(t,
-					resourceassert.ServiceUserResource(t, userModelAllAttributesChanged(loginName+"_other_login").ResourceReference()).
+					resourceassert.ServiceUserResource(t, userModelAllAttributesChanged(newLoginName).ResourceReference()).
 						HasNameString(id.Name()).
-						HasLoginNameString(fmt.Sprintf("%s_other_login", loginName)).
+						HasLoginNameString(newLoginName).
 						HasDisplayNameString("New Display Name").
 						HasEmailString("fake@email.net").
 						HasDisabled(true).
@@ -189,22 +190,22 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            userModelAllAttributesChanged(loginName + "_other_login").ResourceReference(),
+				ResourceName:            userModelAllAttributesChanged(newLoginName).ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"days_to_expiry", "mins_to_unlock", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedServiceUserResource(t, id.Name()).
 						HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-						HasLoginNameString(strings.ToUpper(fmt.Sprintf("%s_other_login", loginName))),
+						HasLoginNameString(strings.ToUpper(newLoginName)),
 				),
 			},
 			// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
 			{
 				PreConfig: func() {
-					acc.TestClient().User.SetLoginName(t, id, loginName+"_different_login")
+					acc.TestClient().User.SetLoginName(t, id, loginName)
 				},
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_different_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName)),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/pkg/resources/service_user_acceptance_test.go
+++ b/pkg/resources/service_user_acceptance_test.go
@@ -34,6 +34,8 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 	id := acc.TestClient().Ids.RandomAccountObjectIdentifier()
 	id2 := acc.TestClient().Ids.RandomAccountObjectIdentifier()
 
+	loginName := random.SensitiveAlphanumeric()
+
 	comment := random.Comment()
 	newComment := random.Comment()
 
@@ -45,7 +47,7 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 		WithComment(newComment)
 
 	userModelAllAttributes := model.ServiceUser("w", id.Name()).
-		WithLoginName(id.Name() + "_login").
+		WithLoginName(loginName + "_login").
 		WithDisplayName("Display Name").
 		WithEmail("fake@email.com").
 		WithDisabled("false").
@@ -147,7 +149,7 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 				Check: assertThat(t,
 					resourceassert.ServiceUserResource(t, userModelAllAttributes.ResourceReference()).
 						HasNameString(id.Name()).
-						HasLoginNameString(fmt.Sprintf("%s_login", id.Name())).
+						HasLoginNameString(fmt.Sprintf("%s_login", loginName)).
 						HasDisplayNameString("Display Name").
 						HasEmailString("fake@email.com").
 						HasDisabled(false).
@@ -165,11 +167,11 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: config.FromModels(t, userModelAllAttributesChanged(id.Name()+"_other_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_other_login")),
 				Check: assertThat(t,
-					resourceassert.ServiceUserResource(t, userModelAllAttributesChanged(id.Name()+"_other_login").ResourceReference()).
+					resourceassert.ServiceUserResource(t, userModelAllAttributesChanged(loginName+"_other_login").ResourceReference()).
 						HasNameString(id.Name()).
-						HasLoginNameString(fmt.Sprintf("%s_other_login", id.Name())).
+						HasLoginNameString(fmt.Sprintf("%s_other_login", loginName)).
 						HasDisplayNameString("New Display Name").
 						HasEmailString("fake@email.net").
 						HasDisabled(true).
@@ -187,22 +189,22 @@ func TestAcc_ServiceUser_BasicFlows(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            userModelAllAttributesChanged(id.Name() + "_other_login").ResourceReference(),
+				ResourceName:            userModelAllAttributesChanged(loginName + "_other_login").ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"days_to_expiry", "mins_to_unlock", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedServiceUserResource(t, id.Name()).
 						HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-						HasLoginNameString(fmt.Sprintf("%s_OTHER_LOGIN", id.Name())),
+						HasLoginNameString(strings.ToUpper(fmt.Sprintf("%s_other_login", loginName))),
 				),
 			},
 			// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
 			{
 				PreConfig: func() {
-					acc.TestClient().User.SetLoginName(t, id, id.Name()+"_different_login")
+					acc.TestClient().User.SetLoginName(t, id, loginName+"_different_login")
 				},
-				Config: config.FromModels(t, userModelAllAttributesChanged(id.Name()+"_different_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_different_login")),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -45,6 +45,7 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 	key2, _ := random.GenerateRSAPublicKey(t)
 
 	loginName := random.SensitiveAlphanumeric()
+	newLoginName := random.SensitiveAlphanumeric()
 	pass := random.Password()
 	newPass := random.Password()
 
@@ -54,7 +55,7 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 
 	userModelAllAttributes := model.User("w", id.Name()).
 		WithPassword(pass).
-		WithLoginName(loginName + "_login").
+		WithLoginName(loginName).
 		WithDisplayName("Display Name").
 		WithFirstName("Jan").
 		WithMiddleName("Jakub").
@@ -178,7 +179,7 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 					resourceassert.UserResource(t, userModelAllAttributes.ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(pass).
-						HasLoginNameString(fmt.Sprintf("%s_login", loginName)).
+						HasLoginNameString(loginName).
 						HasDisplayNameString("Display Name").
 						HasFirstNameString("Jan").
 						HasMiddleNameString("Jakub").
@@ -202,12 +203,12 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 			},
 			// CHANGE PROPERTIES
 			{
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_other_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(newLoginName)),
 				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelAllAttributesChanged(loginName+"_other_login").ResourceReference()).
+					resourceassert.UserResource(t, userModelAllAttributesChanged(newLoginName).ResourceReference()).
 						HasNameString(id.Name()).
 						HasPasswordString(newPass).
-						HasLoginNameString(fmt.Sprintf("%s_other_login", loginName)).
+						HasLoginNameString(newLoginName).
 						HasDisplayNameString("New Display Name").
 						HasFirstNameString("Janek").
 						HasMiddleNameString("Kuba").
@@ -231,22 +232,22 @@ func TestAcc_User_BasicFlows(t *testing.T) {
 			},
 			// IMPORT
 			{
-				ResourceName:            userModelAllAttributesChanged(loginName + "_other_login").ResourceReference(),
+				ResourceName:            userModelAllAttributesChanged(newLoginName).ResourceReference(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password", "disable_mfa", "days_to_expiry", "mins_to_unlock", "mins_to_bypass_mfa", "default_namespace", "login_name", "show_output.0.days_to_expiry"},
 				ImportStateCheck: assertThatImport(t,
 					resourceassert.ImportedUserResource(t, id.Name()).
 						HasDefaultNamespaceString("ONE_PART_NAMESPACE").
-						HasLoginNameString(strings.ToUpper(fmt.Sprintf("%s_other_login", loginName))),
+						HasLoginNameString(strings.ToUpper(newLoginName)),
 				),
 			},
 			// CHANGE PROP TO THE CURRENT SNOWFLAKE VALUE
 			{
 				PreConfig: func() {
-					acc.TestClient().User.SetLoginName(t, id, loginName+"_different_login")
+					acc.TestClient().User.SetLoginName(t, id, loginName)
 				},
-				Config: config.FromModels(t, userModelAllAttributesChanged(loginName+"_different_login")),
+				Config: config.FromModels(t, userModelAllAttributesChanged(loginName)),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),

--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -109,7 +109,7 @@ func TestInt_Account(t *testing.T) {
 	}
 
 	t.Run("create: minimal", func(t *testing.T) {
-		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -130,7 +130,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: user type service", func(t *testing.T) {
-		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		name := random.AdminName()
 		key, _ := random.GenerateRSAPublicKey(t)
 		email := random.Email()
@@ -152,7 +152,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: user type legacy service", func(t *testing.T) {
-		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -174,7 +174,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: complete", func(t *testing.T) {
-		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -244,7 +244,7 @@ func TestInt_Account(t *testing.T) {
 		oldAccount, oldAccountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(oldAccountCleanup)
 
-		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		newName := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -269,7 +269,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		newName := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -307,7 +307,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
+		newName := testClientHelper().Ids.RandomSensitiveAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{

--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -110,7 +110,7 @@ func TestInt_Account(t *testing.T) {
 
 	t.Run("create: minimal", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		name := testClientHelper().Ids.Alpha()
+		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
 
@@ -131,7 +131,7 @@ func TestInt_Account(t *testing.T) {
 
 	t.Run("create: user type service", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		name := testClientHelper().Ids.Alpha()
+		name := random.AdminName()
 		key, _ := random.GenerateRSAPublicKey(t)
 		email := random.Email()
 
@@ -153,7 +153,7 @@ func TestInt_Account(t *testing.T) {
 
 	t.Run("create: user type legacy service", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		name := testClientHelper().Ids.Alpha()
+		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
 
@@ -175,7 +175,7 @@ func TestInt_Account(t *testing.T) {
 
 	t.Run("create: complete", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		name := testClientHelper().Ids.Alpha()
+		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
 		region := testClientHelper().Context.CurrentRegion(t)
@@ -244,7 +244,7 @@ func TestInt_Account(t *testing.T) {
 		oldAccount, oldAccountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(oldAccountCleanup)
 
-		newName := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -269,7 +269,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -307,7 +307,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{

--- a/pkg/sdk/testint/accounts_integration_test.go
+++ b/pkg/sdk/testint/accounts_integration_test.go
@@ -109,7 +109,7 @@ func TestInt_Account(t *testing.T) {
 	}
 
 	t.Run("create: minimal", func(t *testing.T) {
-		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -130,7 +130,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: user type service", func(t *testing.T) {
-		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		name := random.AdminName()
 		key, _ := random.GenerateRSAPublicKey(t)
 		email := random.Email()
@@ -152,7 +152,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: user type legacy service", func(t *testing.T) {
-		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -174,7 +174,7 @@ func TestInt_Account(t *testing.T) {
 	})
 
 	t.Run("create: complete", func(t *testing.T) {
-		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
+		id := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		name := random.AdminName()
 		password := random.Password()
 		email := random.Email()
@@ -244,7 +244,7 @@ func TestInt_Account(t *testing.T) {
 		oldAccount, oldAccountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(oldAccountCleanup)
 
-		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
+		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -269,7 +269,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
+		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{
@@ -307,7 +307,7 @@ func TestInt_Account(t *testing.T) {
 		account, accountCleanup := testClientHelper().Account.Create(t)
 		t.Cleanup(accountCleanup)
 
-		newName := sdk.NewAccountObjectIdentifier(random.AdminName())
+		newName := testClientHelper().Ids.SensitiveRandomAccountObjectIdentifier()
 		t.Cleanup(testClientHelper().Account.DropFunc(t, newName))
 
 		err := client.Accounts.Alter(ctx, &sdk.AlterAccountOptions{

--- a/pkg/sdk/testint/users_integration_test.go
+++ b/pkg/sdk/testint/users_integration_test.go
@@ -26,7 +26,7 @@ func TestInt_Users(t *testing.T) {
 
 	password := random.Password()
 	email := random.Email()
-	newValue := random.AlphaN(5)
+	newValue := random.SensitiveAlphanumeric()
 	warehouseId := testClientHelper().Ids.WarehouseId()
 	schemaId := testClientHelper().Ids.SchemaId()
 	var schemaIdObjectIdentifier sdk.ObjectIdentifier = schemaId
@@ -122,7 +122,7 @@ func TestInt_Users(t *testing.T) {
 			},
 		}
 		password := random.Password()
-		loginName := random.String()
+		loginName := random.SensitiveAlphanumeric()
 
 		opts := &sdk.CreateUserOptions{
 			OrReplace: sdk.Bool(true),
@@ -171,7 +171,7 @@ func TestInt_Users(t *testing.T) {
 			},
 		}
 		password := random.Password()
-		loginName := random.String()
+		loginName := random.SensitiveAlphanumeric()
 
 		opts := &sdk.CreateUserOptions{
 			IfNotExists: sdk.Bool(true),
@@ -698,7 +698,7 @@ func TestInt_Users(t *testing.T) {
 
 	t.Run("create: other params with hyphen and mixed cases", func(t *testing.T) {
 		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		randomWithHyphenAndMixedCase := strings.ToUpper(random.AlphaN(4)) + "-" + strings.ToLower(random.AlphaN(4))
+		randomWithHyphenAndMixedCase := strings.ToUpper(random.AlphaN(4)) + "-" + strings.ToLower(random.SensitiveAlphanumeric())
 		var namespaceId sdk.ObjectIdentifier = sdk.NewDatabaseObjectIdentifier(randomWithHyphenAndMixedCase, randomWithHyphenAndMixedCase)
 
 		opts := &sdk.CreateUserOptions{


### PR DESCRIPTION
## Changes
- Updated other random helpers to include masking string
- Used masking string in login names and passwords
- Replaced the use of AdminName in places where it wasn't admin name, but rather an identifier or other value that should be masked.