### PR TITLE
fix: Fix handling references to computed fields in context of `show_output`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -12,6 +12,30 @@ across different versions.
 > [!TIP]
 > If you're still using the `Snowflake-Labs/snowflake` source, see [Upgrading from Snowflake-Labs Provider](./SNOWFLAKEDB_MIGRATION.md) to upgrade to the snowflakedb namespace.
 
+## v1.1.0 ➞ v1.1.1
+
+### Fixes in handling references to computed fields in context of `show_output`
+The issue could arise in almost any object using show_output when the following steps happen:
+1. Object is created.
+2. Object's attribute is updated to computed value of other object added in this run.
+
+In such situation the final plan could result in error like this one:
+```
+| Error: Provider produced inconsistent final plan
+|
+| When expanding the plan for snowflake_legacy_service_user.one to include new
+| values learned so far during apply, provider
+| "registry.terraform.io/hashicorp/snowflake" produced an invalid new value for
+| .show_output: was known, but now unknown.
+|
+| This is a bug in the provider, which should be reported in the provider's own
+| issue tracker.
+```
+
+This version fixes this behavior. No action should be required on user side.
+
+References: [#3522](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3522)
+
 ## v1.0.5 ➞ v1.1.0
 
 ### Timeouts in resources

--- a/pkg/resources/custom_diffs.go
+++ b/pkg/resources/custom_diffs.go
@@ -93,7 +93,7 @@ func ComputedIfAnyAttributeChanged(resourceSchema map[string]*schema.Schema, key
 	return customdiff.ComputedIf(key, func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
 		var result bool
 		for _, changedKey := range changedAttributeKeys {
-			if diff.HasChange(changedKey) {
+			if diff.HasChange(changedKey) || !diff.NewValueKnown(changedKey) {
 				oldValue, newValue := diff.GetChange(changedKey)
 				log.Printf("[DEBUG] ComputedIfAnyAttributeChanged: changed key: %s", changedKey)
 

--- a/pkg/resources/user_acceptance_test.go
+++ b/pkg/resources/user_acceptance_test.go
@@ -1795,15 +1795,15 @@ func TestAcc_User_gh3522_proof(t *testing.T) {
 				ExternalProviders: acc.ExternalProviderWithExactVersion("1.0.5"),
 				Config:            gh3522ConfigSecondStep(userId, userId2, comment),
 				// Resulting in:
-				//| Error: Provider produced inconsistent final plan
-				//|
-				//| When expanding the plan for snowflake_legacy_service_user.one to include new
-				//| values learned so far during apply, provider
-				//| "registry.terraform.io/hashicorp/snowflake" produced an invalid new value for
-				//| .show_output: was known, but now unknown.
-				//|
-				//| This is a bug in the provider, which should be reported in the provider's own
-				//| issue tracker.
+				// | Error: Provider produced inconsistent final plan
+				// |
+				// | When expanding the plan for snowflake_legacy_service_user.one to include new
+				// | values learned so far during apply, provider
+				// | "registry.terraform.io/hashicorp/snowflake" produced an invalid new value for
+				// | .show_output: was known, but now unknown.
+				// |
+				// | This is a bug in the provider, which should be reported in the provider's own
+				// | issue tracker.
 				ExpectError: regexp.MustCompile("Provider produced inconsistent final plan"),
 			},
 		},


### PR DESCRIPTION
The issue could arise in almost any object using show_output when the following steps happen:
1. Object is created.
2. Object's attribute is updated to computed value of other object added in this run.

Reason: `diff.HasChange(changedKey)` used in `ComputedIfAnyAttributeChanged` does not trigger, so the whole `show_output` is not marked as a new attribute.

References: #3522 