### PR TITLE
fix: Network policy test fixes

### DIFF
--- a/pkg/acceptance/bettertestspoc/README.md
+++ b/pkg/acceptance/bettertestspoc/README.md
@@ -405,6 +405,7 @@ func (w *WarehouseDatasourceShowOutputAssert) IsEmpty() {
 - remove schema.TypeMap workaround or make it wiser (e.g. during generation we could programmatically gather all schema.TypeMap and use this workaround only for them)
 - support asserting resource id in `assert/resourceassert/*_gen.go`
 - add possibility for object parameter assert not take any identifier (currently there's a workaround in `account_parameters_snowflake_gen.go`, because `SHOW PARAMETERS FOR ACCOUNT` don't take any identifiers)
+- SNOW-2048330: add possibility to override the default value (and optionally default level) used in HasAllDefaults -> HasDefaultParameterValueOnLevel parameter assertions (it's required for cases like asserting `NETWORK_POLICY` which is predefined for our testing environments and causes test failures)
 
 ## Known limitations
 - generating provider config may misbehave when used only with one object/map paramter (like `params`), e.g.:

--- a/pkg/acceptance/bettertestspoc/assert/objectparametersassert/gen/object_parameters_def.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectparametersassert/gen/object_parameters_def.go
@@ -1,6 +1,9 @@
 package gen
 
-import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvidentifiers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+)
 
 type SnowflakeObjectParameters struct {
 	Name              string
@@ -33,7 +36,7 @@ var allObjectsParameters = []SnowflakeObjectParameters{
 		Level:  sdk.ParameterTypeUser,
 		Parameters: []SnowflakeParameter{
 			{ParameterName: string(sdk.UserParameterEnableUnredactedQuerySyntaxError), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
-			{ParameterName: string(sdk.UserParameterNetworkPolicy), ParameterType: "string", DefaultValue: "RESTRICTED_ACCESS", DefaultLevel: "sdk.ParameterTypeAccount"},
+			{ParameterName: string(sdk.UserParameterNetworkPolicy), ParameterType: "string", DefaultValue: testenvidentifiers.NetworkPolicy.Name(), DefaultLevel: "sdk.ParameterTypeAccount"},
 			{ParameterName: string(sdk.UserParameterPreventUnloadToInternalStages), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
 			{ParameterName: string(sdk.UserParameterAbortDetachedQuery), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
 			{ParameterName: string(sdk.UserParameterAutocommit), ParameterType: "bool", DefaultValue: "true", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},

--- a/pkg/acceptance/bettertestspoc/assert/objectparametersassert/gen/object_parameters_def.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectparametersassert/gen/object_parameters_def.go
@@ -33,7 +33,7 @@ var allObjectsParameters = []SnowflakeObjectParameters{
 		Level:  sdk.ParameterTypeUser,
 		Parameters: []SnowflakeParameter{
 			{ParameterName: string(sdk.UserParameterEnableUnredactedQuerySyntaxError), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
-			{ParameterName: string(sdk.UserParameterNetworkPolicy), ParameterType: "string", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
+			{ParameterName: string(sdk.UserParameterNetworkPolicy), ParameterType: "string", DefaultValue: "RESTRICTED_ACCESS", DefaultLevel: "sdk.ParameterTypeAccount"},
 			{ParameterName: string(sdk.UserParameterPreventUnloadToInternalStages), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
 			{ParameterName: string(sdk.UserParameterAbortDetachedQuery), ParameterType: "bool", DefaultValue: "false", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},
 			{ParameterName: string(sdk.UserParameterAutocommit), ParameterType: "bool", DefaultValue: "true", DefaultLevel: "sdk.ParameterTypeSnowflakeDefault"},

--- a/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
@@ -70,7 +70,7 @@ func (u *UserParametersAssert) HasDefaultParameterValueOnLevel(parameterName sdk
 func (u *UserParametersAssert) HasAllDefaults() *UserParametersAssert {
 	return u.
 		HasDefaultParameterValueOnLevel(sdk.UserParameterEnableUnredactedQuerySyntaxError, sdk.ParameterTypeSnowflakeDefault).
-		// TOOD: (temp comment) HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount).
+		// TOOD(SNOW-2048330): HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterPreventUnloadToInternalStages, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAbortDetachedQuery, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAutocommit, sdk.ParameterTypeSnowflakeDefault).

--- a/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectparametersassert/user_parameters_snowflake_gen.go
@@ -70,7 +70,7 @@ func (u *UserParametersAssert) HasDefaultParameterValueOnLevel(parameterName sdk
 func (u *UserParametersAssert) HasAllDefaults() *UserParametersAssert {
 	return u.
 		HasDefaultParameterValueOnLevel(sdk.UserParameterEnableUnredactedQuerySyntaxError, sdk.ParameterTypeSnowflakeDefault).
-		HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeSnowflakeDefault).
+		// TOOD: (temp comment) HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterPreventUnloadToInternalStages, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAbortDetachedQuery, sdk.ParameterTypeSnowflakeDefault).
 		HasDefaultParameterValueOnLevel(sdk.UserParameterAutocommit, sdk.ParameterTypeSnowflakeDefault).
@@ -1024,7 +1024,7 @@ func (u *UserParametersAssert) HasDefaultEnableUnredactedQuerySyntaxErrorValueEx
 }
 
 func (u *UserParametersAssert) HasDefaultNetworkPolicyValueExplicit() *UserParametersAssert {
-	return u.HasNetworkPolicy("")
+	return u.HasNetworkPolicy("RESTRICTED_ACCESS")
 }
 
 func (u *UserParametersAssert) HasDefaultPreventUnloadToInternalStagesValueExplicit() *UserParametersAssert {

--- a/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
@@ -9,7 +9,7 @@ import (
 func (u *UserResourceParametersAssert) HasAllDefaults() *UserResourceParametersAssert {
 	return u.
 		HasEnableUnredactedQuerySyntaxError(false).
-		HasNetworkPolicy("").
+		HasNetworkPolicy("RESTRICTED_ACCESS").
 		HasPreventUnloadToInternalStages(false).
 		HasAbortDetachedQuery(false).
 		HasAutocommit(true).

--- a/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
@@ -1,6 +1,7 @@
 package resourceparametersassert
 
 import (
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvidentifiers"
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -9,7 +10,7 @@ import (
 func (u *UserResourceParametersAssert) HasAllDefaults() *UserResourceParametersAssert {
 	return u.
 		HasEnableUnredactedQuerySyntaxError(false).
-		HasNetworkPolicy("RESTRICTED_ACCESS").
+		HasNetworkPolicy(testenvidentifiers.NetworkPolicy.Name()).
 		HasPreventUnloadToInternalStages(false).
 		HasAbortDetachedQuery(false).
 		HasAutocommit(true).

--- a/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
+++ b/pkg/acceptance/bettertestspoc/assert/resourceparametersassert/user_resource_parameters_ext.go
@@ -1,8 +1,9 @@
 package resourceparametersassert
 
 import (
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvidentifiers"
 	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvidentifiers"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )

--- a/pkg/acceptance/testenvidentifiers/test_identifiers.go
+++ b/pkg/acceptance/testenvidentifiers/test_identifiers.go
@@ -1,0 +1,7 @@
+package testenvidentifiers
+
+import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+
+var (
+	NetworkPolicy = sdk.NewAccountObjectIdentifier("RESTRICTED_ACCESS")
+)

--- a/pkg/acceptance/testenvidentifiers/test_identifiers.go
+++ b/pkg/acceptance/testenvidentifiers/test_identifiers.go
@@ -2,6 +2,4 @@ package testenvidentifiers
 
 import "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 
-var (
-	NetworkPolicy = sdk.NewAccountObjectIdentifier("RESTRICTED_ACCESS")
-)
+var NetworkPolicy = sdk.NewAccountObjectIdentifier("RESTRICTED_ACCESS")

--- a/pkg/resources/user_password_policy_attachment_acceptance_test.go
+++ b/pkg/resources/user_password_policy_attachment_acceptance_test.go
@@ -64,47 +64,6 @@ func TestAcc_UserPasswordPolicyAttachment(t *testing.T) {
 	})
 }
 
-// Adding this test to check if it will fail sometimes. It should, based on:
-// - https://github.com/Snowflake-Labs/terraform-provider-snowflake/issues/3005
-// - https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/2627
-// but haven't (at least during manual runs).
-// The behavior was fixed in https://github.com/Snowflake-Labs/terraform-provider-snowflake/pull/2627
-// so the problem should not occur in the newest provider versions.
-func TestAcc_UserPasswordPolicyAttachment_gh3005(t *testing.T) {
-	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
-	acc.TestAccPreCheck(t)
-
-	user, userCleanup := acc.TestClient().User.CreateUser(t)
-	t.Cleanup(userCleanup)
-
-	userId := user.ID()
-	passwordPolicyId := acc.TestClient().Ids.RandomSchemaObjectIdentifier()
-
-	resource.Test(t, resource.TestCase{
-		ExternalProviders: acc.ExternalProviderWithExactVersion("0.87.0"),
-		PreCheck:          func() { acc.TestAccPreCheck(t) },
-		CheckDestroy:      acc.CheckUserPasswordPolicyAttachmentDestroy(t),
-		Steps: []resource.TestStep{
-			// CREATE
-			{
-				PreConfig: func() { acc.SetV097CompatibleConfigPathEnv(t) },
-				Config:    userPasswordPolicyAttachmentConfigV087(userId, passwordPolicyId),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("snowflake_user_password_policy_attachment.ppa", "user_name", userId.Name()),
-					resource.TestCheckResourceAttr("snowflake_user_password_policy_attachment.ppa", "password_policy_name", passwordPolicyId.FullyQualifiedName()),
-					resource.TestCheckResourceAttr("snowflake_user_password_policy_attachment.ppa", "id", fmt.Sprintf("%s|%s", userId.FullyQualifiedName(), passwordPolicyId.FullyQualifiedName())),
-				),
-			},
-			// IMPORT
-			{
-				ResourceName:      "snowflake_user_password_policy_attachment.ppa",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func userPasswordPolicyAttachmentConfig(userId sdk.AccountObjectIdentifier, passwordPolicyId sdk.SchemaObjectIdentifier) string {
 	return fmt.Sprintf(`
 resource "snowflake_password_policy" "pp" {
@@ -116,22 +75,6 @@ resource "snowflake_password_policy" "pp" {
 resource "snowflake_user_password_policy_attachment" "ppa" {
 	password_policy_name = snowflake_password_policy.pp.fully_qualified_name
 	user_name = "%[1]s"
-}
-`, userId.Name(), passwordPolicyId.DatabaseName(), passwordPolicyId.SchemaName(), passwordPolicyId.Name())
-}
-
-func userPasswordPolicyAttachmentConfigV087(userId sdk.AccountObjectIdentifier, passwordPolicyId sdk.SchemaObjectIdentifier) string {
-	return fmt.Sprintf(`
-resource "snowflake_password_policy" "pp" {
-	database   = "%[2]s"
-	schema     = "%[3]s"
-	name       = "%[4]s"
-}
-
-resource "snowflake_user_password_policy_attachment" "ppa" {
-	depends_on = [snowflake_password_policy.pp]
-	password_policy_name = "\"%[2]s\".\"%[3]s\".\"%[4]s\""
-	user_name =  "%[1]s"
 }
 `, userId.Name(), passwordPolicyId.DatabaseName(), passwordPolicyId.SchemaName(), passwordPolicyId.Name())
 }

--- a/pkg/sdk/testint/policy_references_integration_test.go
+++ b/pkg/sdk/testint/policy_references_integration_test.go
@@ -5,6 +5,8 @@ package testint
 import (
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/stretchr/testify/require"
 )
@@ -35,9 +37,14 @@ func TestInt_PolicyReferences(t *testing.T) {
 
 		policyReferences, err := client.PolicyReferences.GetForEntity(ctx, sdk.NewGetForEntityPolicyReferenceRequest(user.ID(), sdk.PolicyEntityDomainUser))
 		require.NoError(t, err)
-		require.Equal(t, 1, len(policyReferences))
-		require.Equal(t, passwordPolicyId.Name(), policyReferences[0].PolicyName)
-		require.Equal(t, sdk.PolicyKindPasswordPolicy, policyReferences[0].PolicyKind)
+		require.GreaterOrEqual(t, len(policyReferences), 1)
+
+		passwordPolicy, err := collections.FindFirst(policyReferences, func(reference sdk.PolicyReference) bool {
+			return reference.PolicyKind == sdk.PolicyKindPasswordPolicy && reference.PolicyName == passwordPolicyId.Name()
+		})
+		require.NoError(t, err)
+		require.Equal(t, passwordPolicyId.Name(), passwordPolicy.PolicyName)
+		require.Equal(t, sdk.PolicyKindPasswordPolicy, passwordPolicy.PolicyKind)
 	})
 
 	t.Run("tag domain", func(t *testing.T) {


### PR DESCRIPTION
## Changes
- Adjust tests to account for new network policy
  - Change default value for user network policy parameter to RESTRICTED_ACCESS and change it's default level to ACCOUNT
  - Adjust CheckUserPasswordPolicyAttachmentDestroy logic to only check for password policies (not all policies as it was previously doing)
  - Remove TestAcc_UserPasswordPolicyAttachment_gh3005 as it was referring to the old provider code (v0.87.0), which had a bug and was mapping POLICY_STATUS as a non-null field. It was fixed later on and it will be always failing because of the network policy on the account that has always null status (I'm guessing status for this policy doesn't matter).

## Next steps
  - Adjust parameter asserts, particularly HasAllDefaults function to check for default values on the level by checking with locally defined default value (in the object_parameters_def.go) rather than from Snowflake. Because of the current behavior, the network policy would always fail, because the Snowflake default is set to an empty string, not RESTRICTED_ACCESS, as it is in our parameter definitions.
    - Create a follow-up ticket and put it into commented out `HasDefaultParameterValueOnLevel(sdk.UserParameterNetworkPolicy, sdk.ParameterTypeAccount)`