### PR TITLE
chore: Use opts for reading TOML config

### DIFF
--- a/framework/provider/provider.go
+++ b/framework/provider/provider.go
@@ -745,13 +745,13 @@ func (p *SnowflakeProvider) Configure(ctx context.Context, req provider.Configur
 
 	if profile != "" {
 		if profile == "default" {
-			defaultConfig := sdk.DefaultConfig()
+			defaultConfig := sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 			if defaultConfig.Account == "" || defaultConfig.User == "" {
 				resp.Diagnostics.AddError("Error retrieving default profile config", "default profile not found in config file")
 			}
 			config = sdk.MergeConfig(config, defaultConfig)
 		} else {
-			profileConfig, err := sdk.ProfileConfig(profile)
+			profileConfig, err := sdk.ProfileConfig(profile, sdk.WithVerifyPermissions(true))
 			if err != nil {
 				resp.Diagnostics.AddError("Error retrieving profile config", err.Error())
 			}

--- a/framework/provider/provider.go
+++ b/framework/provider/provider.go
@@ -745,13 +745,13 @@ func (p *SnowflakeProvider) Configure(ctx context.Context, req provider.Configur
 
 	if profile != "" {
 		if profile == "default" {
-			defaultConfig := sdk.DefaultConfig(true)
+			defaultConfig := sdk.DefaultConfig()
 			if defaultConfig.Account == "" || defaultConfig.User == "" {
 				resp.Diagnostics.AddError("Error retrieving default profile config", "default profile not found in config file")
 			}
 			config = sdk.MergeConfig(config, defaultConfig)
 		} else {
-			profileConfig, err := sdk.ProfileConfig(profile, true)
+			profileConfig, err := sdk.ProfileConfig(profile)
 			if err != nil {
 				resp.Diagnostics.AddError("Error retrieving profile config", err.Error())
 			}

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -80,7 +80,7 @@ func init() {
 	}
 	_ = testAccProtoV6ProviderFactoriesNew
 
-	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default)
+	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default, sdk.WithVerifyPermissions(true))
 	if err != nil {
 		log.Panicf("Could not read configuration from profile: %v", err)
 	}
@@ -95,7 +95,7 @@ func init() {
 	}
 	atc.client = client
 
-	cfg, err := sdk.ProfileConfig(testprofiles.Secondary)
+	cfg, err := sdk.ProfileConfig(testprofiles.Secondary, sdk.WithVerifyPermissions(true))
 	if err != nil {
 		log.Panicf("Config for the secondary client is needed to run acceptance tests, err: %v", err)
 	}

--- a/pkg/acceptance/testing.go
+++ b/pkg/acceptance/testing.go
@@ -80,7 +80,7 @@ func init() {
 	}
 	_ = testAccProtoV6ProviderFactoriesNew
 
-	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default, true)
+	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default)
 	if err != nil {
 		log.Panicf("Could not read configuration from profile: %v", err)
 	}
@@ -95,7 +95,7 @@ func init() {
 	}
 	atc.client = client
 
-	cfg, err := sdk.ProfileConfig(testprofiles.Secondary, true)
+	cfg, err := sdk.ProfileConfig(testprofiles.Secondary)
 	if err != nil {
 		log.Panicf("Config for the secondary client is needed to run acceptance tests, err: %v", err)
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -588,14 +588,14 @@ func expandStringList(configured []interface{}) []string {
 
 func getDriverConfigFromTOML(profile string, verifyPermissions bool) (*gosnowflake.Config, error) {
 	if profile == "default" {
-		return sdk.DefaultConfig(verifyPermissions), nil
+		return sdk.DefaultConfig(sdk.WithVerifyPermissions(verifyPermissions)), nil
 	}
 	path, err := sdk.GetConfigFileName()
 	if err != nil {
 		return nil, err
 	}
 
-	profileConfig, err := sdk.ProfileConfig(profile, verifyPermissions)
+	profileConfig, err := sdk.ProfileConfig(profile, sdk.WithVerifyPermissions(verifyPermissions))
 	if err != nil {
 		return nil, fmt.Errorf(`could not retrieve "%s" profile config from file %s: %w`, profile, path, err)
 	}

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -110,7 +110,7 @@ func NewClient(cfg *gosnowflake.Config) (*Client, error) {
 	var err error
 	if cfg == nil {
 		log.Printf("[DEBUG] Searching for default config in credentials chain...")
-		cfg = DefaultConfig()
+		cfg = DefaultConfig(WithVerifyPermissions(true))
 	}
 
 	dsn, err := gosnowflake.DSN(cfg)

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -110,7 +110,7 @@ func NewClient(cfg *gosnowflake.Config) (*Client, error) {
 	var err error
 	if cfg == nil {
 		log.Printf("[DEBUG] Searching for default config in credentials chain...")
-		cfg = DefaultConfig(true)
+		cfg = DefaultConfig()
 	}
 
 	dsn, err := gosnowflake.DSN(cfg)

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -57,7 +57,7 @@ func TestClient_queryOne(t *testing.T) {
 
 func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
 	t.Run("get default gosnowflake driver logging level", func(t *testing.T) {
-		config := DefaultConfig(true)
+		config := DefaultConfig()
 		_, err := NewClient(config)
 		require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
 	})
 
 	t.Run("set gosnowflake driver logging level with config", func(t *testing.T) {
-		config := DefaultConfig(true)
+		config := DefaultConfig()
 		config.Tracing = "trace"
 		_, err := NewClient(config)
 		require.NoError(t, err)

--- a/pkg/sdk/client_integration_test.go
+++ b/pkg/sdk/client_integration_test.go
@@ -57,7 +57,7 @@ func TestClient_queryOne(t *testing.T) {
 
 func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
 	t.Run("get default gosnowflake driver logging level", func(t *testing.T) {
-		config := DefaultConfig()
+		config := DefaultConfig(WithVerifyPermissions(true))
 		_, err := NewClient(config)
 		require.NoError(t, err)
 
@@ -71,7 +71,7 @@ func TestClient_NewClientDriverLoggingLevel(t *testing.T) {
 	})
 
 	t.Run("set gosnowflake driver logging level with config", func(t *testing.T) {
-		config := DefaultConfig()
+		config := DefaultConfig(WithVerifyPermissions(true))
 		config.Tracing = "trace"
 		_, err := NewClient(config)
 		require.NoError(t, err)

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -35,7 +35,7 @@ func fourthTestClient(t *testing.T) *Client {
 func testClient(t *testing.T, profile string) *Client {
 	t.Helper()
 
-	config, err := ProfileConfig(profile)
+	config, err := ProfileConfig(profile, WithVerifyPermissions(true))
 	if err != nil {
 		t.Skipf("Snowflake %s profile not configured. Must be set in ~/.snowflake/config", profile)
 	}

--- a/pkg/sdk/helper_test.go
+++ b/pkg/sdk/helper_test.go
@@ -35,7 +35,7 @@ func fourthTestClient(t *testing.T) *Client {
 func testClient(t *testing.T, profile string) *Client {
 	t.Helper()
 
-	config, err := ProfileConfig(profile, true)
+	config, err := ProfileConfig(profile)
 	if err != nil {
 		t.Skipf("Snowflake %s profile not configured. Must be set in ~/.snowflake/config", profile)
 	}

--- a/pkg/sdk/legacy_config_test.go
+++ b/pkg/sdk/legacy_config_test.go
@@ -262,7 +262,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 	t.Run("with found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
 
-		config, err := ProfileConfig("securityadmin")
+		config, err := ProfileConfig("securityadmin", WithVerifyPermissions(true))
 		require.NoError(t, err)
 		require.NotNil(t, config.PrivateKey)
 
@@ -316,7 +316,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 	t.Run("with not found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
 
-		config, err := ProfileConfig("orgadmin")
+		config, err := ProfileConfig("orgadmin", WithVerifyPermissions(true))
 		require.NoError(t, err)
 		require.Nil(t, config)
 	})
@@ -325,7 +325,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 		filename := random.AlphaN(8)
 		t.Setenv(snowflakeenvs.ConfigPath, filename)
 
-		config, err := ProfileConfig("orgadmin")
+		config, err := ProfileConfig("orgadmin", WithVerifyPermissions(true))
 		require.ErrorContains(t, err, fmt.Sprintf("could not load config file: reading information about the config file: stat %s: no such file or directory", filename))
 		require.Nil(t, config)
 	})

--- a/pkg/sdk/legacy_config_test.go
+++ b/pkg/sdk/legacy_config_test.go
@@ -262,7 +262,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 	t.Run("with found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
 
-		config, err := ProfileConfig("securityadmin", true)
+		config, err := ProfileConfig("securityadmin")
 		require.NoError(t, err)
 		require.NotNil(t, config.PrivateKey)
 
@@ -316,7 +316,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 	t.Run("with not found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
 
-		config, err := ProfileConfig("orgadmin", true)
+		config, err := ProfileConfig("orgadmin")
 		require.NoError(t, err)
 		require.Nil(t, config)
 	})
@@ -325,7 +325,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 		filename := random.AlphaN(8)
 		t.Setenv(snowflakeenvs.ConfigPath, filename)
 
-		config, err := ProfileConfig("orgadmin", true)
+		config, err := ProfileConfig("orgadmin")
 		require.ErrorContains(t, err, fmt.Sprintf("could not load config file: reading information about the config file: stat %s: no such file or directory", filename))
 		require.Nil(t, config)
 	})

--- a/pkg/sdk/testint/basic_object_tracking_integration_test.go
+++ b/pkg/sdk/testint/basic_object_tracking_integration_test.go
@@ -103,7 +103,7 @@ func TestInt_AppName(t *testing.T) {
 	t.Skip("there no way to check client application name by querying Snowflake's")
 
 	version := "v0.99.0"
-	config := sdk.DefaultConfig()
+	config := sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 	config.Application = fmt.Sprintf("terraform-provider-snowflake:%s", version)
 	client, err := sdk.NewClient(config)
 	require.NoError(t, err)

--- a/pkg/sdk/testint/basic_object_tracking_integration_test.go
+++ b/pkg/sdk/testint/basic_object_tracking_integration_test.go
@@ -103,7 +103,7 @@ func TestInt_AppName(t *testing.T) {
 	t.Skip("there no way to check client application name by querying Snowflake's")
 
 	version := "v0.99.0"
-	config := sdk.DefaultConfig(true)
+	config := sdk.DefaultConfig()
 	config.Application = fmt.Sprintf("terraform-provider-snowflake:%s", version)
 	client, err := sdk.NewClient(config)
 	require.NoError(t, err)

--- a/pkg/sdk/testint/client_integration_test.go
+++ b/pkg/sdk/testint/client_integration_test.go
@@ -25,7 +25,7 @@ import (
 // TODO [SNOW-1827310]: use generated config for these tests
 func TestInt_Client_NewClient(t *testing.T) {
 	t.Run("with default config", func(t *testing.T) {
-		config := sdk.DefaultConfig()
+		config := sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 		_, err := sdk.NewClient(config)
 		require.NoError(t, err)
 	})
@@ -35,7 +35,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 		require.NoError(t, err)
 		t.Setenv(snowflakeenvs.ConfigPath, dir)
 
-		config := sdk.DefaultConfig()
+		config := sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 		_, err = sdk.NewClient(config)
 		require.ErrorContains(t, err, "260000: account is empty")
 	})
@@ -46,7 +46,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 
 		t.Setenv(snowflakeenvs.ConfigPath, tmpServiceUserConfig.Path)
 
-		config, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile)
+		config, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile, sdk.WithVerifyPermissions(true))
 		require.NoError(t, err)
 		require.NotNil(t, config)
 
@@ -62,7 +62,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 
 		t.Setenv(snowflakeenvs.ConfigPath, tomlConfig.Path)
 
-		_, err := sdk.ProfileConfig(tomlConfig.Profile)
+		_, err := sdk.ProfileConfig(tomlConfig.Profile, sdk.WithVerifyPermissions(true))
 		require.ErrorContains(t, err, fmt.Sprintf("could not load config file: config file %s is too big - maximum allowed size is 10MB", tomlConfig.Path))
 	})
 
@@ -99,7 +99,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 	})
 
 	t.Run("with missing config - should not care about correct env variables", func(t *testing.T) {
-		config, err := sdk.ProfileConfig(testprofiles.Default)
+		config, err := sdk.ProfileConfig(testprofiles.Default, sdk.WithVerifyPermissions(true))
 		require.NoError(t, err)
 		require.NotNil(t, config)
 
@@ -112,13 +112,13 @@ func TestInt_Client_NewClient(t *testing.T) {
 		require.NoError(t, err)
 		t.Setenv(snowflakeenvs.ConfigPath, dir)
 
-		config = sdk.DefaultConfig()
+		config = sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 		_, err = sdk.NewClient(config)
 		require.ErrorContains(t, err, "260000: account is empty")
 	})
 
 	t.Run("registers snowflake driver", func(t *testing.T) {
-		config := sdk.DefaultConfig()
+		config := sdk.DefaultConfig(sdk.WithVerifyPermissions(true))
 		_, err := sdk.NewClient(config)
 		require.NoError(t, err)
 

--- a/pkg/sdk/testint/client_integration_test.go
+++ b/pkg/sdk/testint/client_integration_test.go
@@ -5,11 +5,14 @@ package testint
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/tracking"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
@@ -22,7 +25,7 @@ import (
 // TODO [SNOW-1827310]: use generated config for these tests
 func TestInt_Client_NewClient(t *testing.T) {
 	t.Run("with default config", func(t *testing.T) {
-		config := sdk.DefaultConfig(true)
+		config := sdk.DefaultConfig()
 		_, err := sdk.NewClient(config)
 		require.NoError(t, err)
 	})
@@ -32,7 +35,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 		require.NoError(t, err)
 		t.Setenv(snowflakeenvs.ConfigPath, dir)
 
-		config := sdk.DefaultConfig(true)
+		config := sdk.DefaultConfig()
 		_, err = sdk.NewClient(config)
 		require.ErrorContains(t, err, "260000: account is empty")
 	})
@@ -43,7 +46,7 @@ func TestInt_Client_NewClient(t *testing.T) {
 
 		t.Setenv(snowflakeenvs.ConfigPath, tmpServiceUserConfig.Path)
 
-		config, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile, true)
+		config, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile)
 		require.NoError(t, err)
 		require.NotNil(t, config)
 
@@ -51,8 +54,52 @@ func TestInt_Client_NewClient(t *testing.T) {
 		require.ErrorContains(t, err, "JWT token is invalid")
 	})
 
+	t.Run("with too big file", func(t *testing.T) {
+		c := make([]byte, 11*1024*1024)
+		tomlConfig := testClientHelper().StoreTempTomlConfig(t, func(profile string) string {
+			return string(c)
+		})
+
+		t.Setenv(snowflakeenvs.ConfigPath, tomlConfig.Path)
+
+		_, err := sdk.ProfileConfig(tomlConfig.Profile)
+		require.ErrorContains(t, err, fmt.Sprintf("could not load config file: config file %s is too big - maximum allowed size is 10MB", tomlConfig.Path))
+	})
+
+	t.Run("with incorrect privileges and enabled check", func(t *testing.T) {
+		if oswrapper.IsRunningOnWindows() {
+			t.Skip("checking file permissions on Windows is currently done in manual tests package")
+		}
+		permissions := fs.FileMode(0o755)
+		tmpServiceUser := testClientHelper().SetUpTemporaryServiceUser(t)
+		tmpServiceUserConfig := testClientHelper().TempTomlConfigWithCustomPermissionsForServiceUser(t, tmpServiceUser, permissions)
+
+		t.Setenv(snowflakeenvs.ConfigPath, tmpServiceUserConfig.Path)
+
+		_, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile, sdk.WithVerifyPermissions(true))
+		require.ErrorContains(t, err, fmt.Sprintf("could not load config file: config file %s has unsafe permissions - %#o", tmpServiceUserConfig.Path, permissions))
+	})
+
+	t.Run("with incorrect privileges and disabled check (default)", func(t *testing.T) {
+		if oswrapper.IsRunningOnWindows() {
+			t.Skip("checking file permissions on Windows is currently done in manual tests package")
+		}
+		permissions := fs.FileMode(0o755)
+		tmpServiceUser := testClientHelper().SetUpTemporaryServiceUser(t)
+		tmpServiceUserConfig := testClientHelper().TempTomlConfigWithCustomPermissionsForServiceUser(t, tmpServiceUser, permissions)
+
+		t.Setenv(snowflakeenvs.ConfigPath, tmpServiceUserConfig.Path)
+
+		config, err := sdk.ProfileConfig(tmpServiceUserConfig.Profile)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+
+		_, err = sdk.NewClient(config)
+		require.NoError(t, err)
+	})
+
 	t.Run("with missing config - should not care about correct env variables", func(t *testing.T) {
-		config, err := sdk.ProfileConfig(testprofiles.Default, true)
+		config, err := sdk.ProfileConfig(testprofiles.Default)
 		require.NoError(t, err)
 		require.NotNil(t, config)
 
@@ -65,13 +112,13 @@ func TestInt_Client_NewClient(t *testing.T) {
 		require.NoError(t, err)
 		t.Setenv(snowflakeenvs.ConfigPath, dir)
 
-		config = sdk.DefaultConfig(true)
+		config = sdk.DefaultConfig()
 		_, err = sdk.NewClient(config)
 		require.ErrorContains(t, err, "260000: account is empty")
 	})
 
 	t.Run("registers snowflake driver", func(t *testing.T) {
-		config := sdk.DefaultConfig(true)
+		config := sdk.DefaultConfig()
 		_, err := sdk.NewClient(config)
 		require.NoError(t, err)
 

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -113,7 +113,7 @@ func (itc *integrationTestContext) initialize() error {
 		return errors.New("test object suffix is required for this test run")
 	}
 
-	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default)
+	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default, sdk.WithVerifyPermissions(true))
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (itc *integrationTestContext) initialize() error {
 
 	// TODO [SNOW-1763603]: improve setup; this is a quick workaround for faster local testing
 	if os.Getenv(string(testenvs.SimplifiedIntegrationTestsSetup)) == "" {
-		config, err := sdk.ProfileConfig(testprofiles.Secondary)
+		config, err := sdk.ProfileConfig(testprofiles.Secondary, sdk.WithVerifyPermissions(true))
 		if err != nil {
 			return err
 		}

--- a/pkg/sdk/testint/setup_test.go
+++ b/pkg/sdk/testint/setup_test.go
@@ -113,7 +113,7 @@ func (itc *integrationTestContext) initialize() error {
 		return errors.New("test object suffix is required for this test run")
 	}
 
-	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default, true)
+	defaultConfig, err := sdk.ProfileConfig(testprofiles.Default)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func (itc *integrationTestContext) initialize() error {
 
 	// TODO [SNOW-1763603]: improve setup; this is a quick workaround for faster local testing
 	if os.Getenv(string(testenvs.SimplifiedIntegrationTestsSetup)) == "" {
-		config, err := sdk.ProfileConfig(testprofiles.Secondary, true)
+		config, err := sdk.ProfileConfig(testprofiles.Secondary)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Use opts pattern in for building provider config.
- Add some more integration tests.
- In general, the setup of the tests is the same for now, they can be simplified in v2, just to be more sure.

## TODO
- Remove unnecessary opts when permission verification is enabled by default in v2.