### PR TITLE
fix: Add single quotes to CSV_TIMESTAMP_FORMAT parameter value

### DIFF
--- a/pkg/resources/account_parameter_acceptance_test.go
+++ b/pkg/resources/account_parameter_acceptance_test.go
@@ -176,3 +176,20 @@ func TestAcc_AccountParameter_INITIAL_REPLICATION_SIZE_LIMIT_IN_TB(t *testing.T)
 		},
 	})
 }
+
+func TestAcc_AccountParameter_CSV_TIMESTAMP_FORMAT(t *testing.T) {
+	accountParameterModel := model.AccountParameter("test", string(sdk.AccountParameterCsvTimestampFormat), "YYYY-MM-DD")
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             acc.CheckAccountParameterUnset(t, sdk.AccountParameterCsvTimestampFormat),
+		Steps: []resource.TestStep{
+			{
+				Config: config.FromModels(t, accountParameterModel),
+				Check: assertThat(t, resourceassert.AccountParameterResource(t, accountParameterModel.ResourceReference()).
+					HasKeyString(string(sdk.AccountParameterCsvTimestampFormat)).
+					HasValueString("YYYY-MM-DD"),
+				),
+			},
+		},
+	})
+}

--- a/pkg/sdk/parameters.go
+++ b/pkg/sdk/parameters.go
@@ -1459,7 +1459,7 @@ type SessionParameters struct {
 	ClientSessionKeepAlive                   *bool                             `ddl:"parameter" sql:"CLIENT_SESSION_KEEP_ALIVE"`
 	ClientSessionKeepAliveHeartbeatFrequency *int                              `ddl:"parameter" sql:"CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY"`
 	ClientTimestampTypeMapping               *ClientTimestampTypeMapping       `ddl:"parameter,single_quotes" sql:"CLIENT_TIMESTAMP_TYPE_MAPPING"`
-	CsvTimestampFormat                       *string                           `ddl:"parameter" sql:"CSV_TIMESTAMP_FORMAT"`
+	CsvTimestampFormat                       *string                           `ddl:"parameter,single_quotes" sql:"CSV_TIMESTAMP_FORMAT"`
 	DateInputFormat                          *string                           `ddl:"parameter,single_quotes" sql:"DATE_INPUT_FORMAT"`
 	DateOutputFormat                         *string                           `ddl:"parameter,single_quotes" sql:"DATE_OUTPUT_FORMAT"`
 	EnableUnloadPhysicalTypeOptimization     *bool                             `ddl:"parameter" sql:"ENABLE_UNLOAD_PHYSICAL_TYPE_OPTIMIZATION"`


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

This pull request fixes a SQL syntax error that occurs when setting the CSV_TIMESTAMP_FORMAT parameter using the `snowflake_account_parameter` resource. In the current implementation, parameter values are generated without single quotes in the SQL statement, causing syntax errors when values contain format specifiers like "YYYY-MM-DDTHH24:MI:SS.FF3TZH:TZM".

The fix adds the `single_quotes` tag to the CsvTimestampFormat field in the SessionParameters struct, ensuring values are properly quoted in the generated SQL, similar to other date and time-related parameters. With this change, the provider will correctly generate SQL statements like "ALTER ACCOUNT SET CSV_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH24:MI:SS.FF3TZH:TZM'" instead of the unquoted version that produces errors.

This eliminates the need for users to manually quote parameter values as a workaround.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->

## References
<!-- issues documentation links, etc  -->

* https://github.com/snowflakedb/terraform-provider-snowflake/issues/3580