### PR TITLE
chore: Handle slices in resource model builder generation

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_ext.go
@@ -9,8 +9,12 @@ import (
 
 // WithExternalOauthTokenUserMappingClaim was added to satisfy the default builders. The method itself is not generated because its type is not yet supported.
 // This method will conflict the generated one when the type is supported.
-func (e *ExternalOauthSecurityIntegrationModel) WithExternalOauthTokenUserMappingClaim(externalOauthTokenUserMappingClaim string) *ExternalOauthSecurityIntegrationModel {
-	e.ExternalOauthTokenUserMappingClaim = tfconfig.SetVariable(tfconfig.StringVariable(externalOauthTokenUserMappingClaim))
+func (e *ExternalOauthSecurityIntegrationModel) WithExternalOauthTokenUserMappingClaim(values []string) *ExternalOauthSecurityIntegrationModel {
+	e.ExternalOauthTokenUserMappingClaim = tfconfig.SetVariable(
+		collections.Map(values, func(value string) tfconfig.Variable {
+			return tfconfig.StringVariable(value)
+		})...,
+	)
 	return e
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_gen.go
@@ -43,7 +43,7 @@ func ExternalOauthSecurityIntegration(
 	enabled bool,
 	externalOauthIssuer string,
 	externalOauthSnowflakeUserMappingAttribute string,
-	externalOauthTokenUserMappingClaim,
+	externalOauthTokenUserMappingClaim []string,
 	externalOauthType string,
 	name string,
 ) *ExternalOauthSecurityIntegrationModel {
@@ -61,7 +61,7 @@ func ExternalOauthSecurityIntegrationWithDefaultMeta(
 	enabled bool,
 	externalOauthIssuer string,
 	externalOauthSnowflakeUserMappingAttribute string,
-	externalOauthTokenUserMappingClaim,
+	externalOauthTokenUserMappingClaim []string,
 	externalOauthType string,
 	name string,
 ) *ExternalOauthSecurityIntegrationModel {

--- a/pkg/acceptance/bettertestspoc/config/model/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/model.go
@@ -1,8 +1,10 @@
 package gen
 
 import (
+	"log"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/genhelpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/resources"
@@ -34,6 +36,7 @@ type ResourceConfigBuilderAttributeModel struct {
 }
 
 func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSchemaDetails) ResourceConfigBuilderModel {
+	additionalImports := []string{"encoding/json"}
 	attributes := make([]ResourceConfigBuilderAttributeModel, 0)
 	for _, attr := range resourceSchemaDetails.Attributes {
 		if slices.Contains([]string{resources.ShowOutputAttributeName, resources.ParametersAttributeName, resources.DescribeOutputAttributeName}, attr.Name) {
@@ -70,6 +73,14 @@ func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSch
 		case schema.TypeString:
 			attributeType = "string"
 			variableMethod = "StringVariable"
+		case schema.TypeList, schema.TypeSet:
+			// We only run it for the required attributes because the `With` methods are not yet generated; we don't need to set the `variableMethod`.
+			// For now, the `With` method for complex object will still need to be added to _ext file.
+			if attr.Required {
+				attrType, additionalImport := handleAttributeTypeForListsAndSets(attr, resourceSchemaDetails.Name)
+				attributeType = attrType
+				additionalImports = append(additionalImports, additionalImport)
+			}
 		}
 
 		attributes = append(attributes, ResourceConfigBuilderAttributeModel{
@@ -88,7 +99,38 @@ func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSch
 		Attributes: attributes,
 		PreambleModel: PreambleModel{
 			PackageName:               packageWithGenerateDirective,
-			AdditionalStandardImports: []string{"encoding/json"},
+			AdditionalStandardImports: additionalImports,
 		},
 	}
+}
+
+// handleAttributeTypeForListsAndSets handles model preparation for list and set attributes.
+// For simple types it's handled seamlessly.
+// For complex types, we need to define override in complexListAttributesOverrides.
+// Also, we need to import package (usually sdk) containing the type representing the given object.
+func handleAttributeTypeForListsAndSets(attr genhelpers.SchemaAttribute, resourceName string) (attributeType string, additionalImport string) {
+	switch attr.AttributeSubType {
+	case schema.TypeBool:
+		attributeType = "[]bool"
+	case schema.TypeInt:
+		attributeType = "[]int"
+	case schema.TypeFloat:
+		attributeType = "[]float"
+	case schema.TypeString:
+		attributeType = "[]string"
+	case schema.TypeMap:
+		if v, ok := complexListAttributesOverrides[resourceName]; ok {
+			if t, ok := v[attr.Name]; ok {
+				attributeType = "[]" + t
+				additionalImport = strings.Split(t, ".")[0]
+			} else {
+				log.Printf("[WARN] No complex list attribute override found for resource's %s attribute %s", resourceName, attr.Name)
+			}
+		} else {
+			log.Printf("[WARN] No complex list attribute overrides found for resource %s", resourceName)
+		}
+	default:
+		log.Printf("[WARN] Attribute's %s sub type could not be determined", attr.Name)
+	}
+	return
 }

--- a/pkg/acceptance/bettertestspoc/config/model/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/model.go
@@ -33,6 +33,7 @@ type ResourceConfigBuilderAttributeModel struct {
 	Required       bool
 	VariableMethod string
 	MethodImport   string
+	OriginalType   schema.ValueType
 }
 
 func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSchemaDetails) ResourceConfigBuilderModel {
@@ -53,6 +54,7 @@ func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSch
 				Required:       attr.Required,
 				VariableMethod: "MultilineWrapperVariable",
 				MethodImport:   "config",
+				OriginalType:   attr.AttributeType,
 			})
 			continue
 		}
@@ -90,6 +92,7 @@ func ModelFromResourceSchemaDetails(resourceSchemaDetails genhelpers.ResourceSch
 			Required:       attr.Required,
 			VariableMethod: variableMethod,
 			MethodImport:   "tfconfig",
+			OriginalType:   attr.AttributeType,
 		})
 	}
 

--- a/pkg/acceptance/bettertestspoc/config/model/gen/overrides.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/overrides.go
@@ -1,5 +1,6 @@
 package gen
 
+// TODO [SNOW-1501905]: extract all overrides to object definitions
 var multilineAttributesOverrides = map[string][]string{
 	"User":                             {"rsa_public_key", "rsa_public_key_2"},
 	"ServiceUser":                      {"rsa_public_key", "rsa_public_key_2"},
@@ -17,4 +18,8 @@ var multilineAttributesOverrides = map[string][]string{
 	"Account":                          {"admin_rsa_public_key"},
 	"Saml2SecurityIntegration":         {"saml2_x509_cert"},
 	"OauthIntegrationForCustomClients": {"oauth_client_rsa_public_key", "oauth_client_rsa_public_key_2"},
+}
+
+var complexListAttributesOverrides = map[string]map[string]string{
+	"MaskingPolicy": {"argument": "sdk.TableColumnSignature"},
 }

--- a/pkg/acceptance/bettertestspoc/config/model/gen/overrides.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/overrides.go
@@ -21,5 +21,6 @@ var multilineAttributesOverrides = map[string][]string{
 }
 
 var complexListAttributesOverrides = map[string]map[string]string{
-	"MaskingPolicy": {"argument": "sdk.TableColumnSignature"},
+	"MaskingPolicy":   {"argument": "sdk.TableColumnSignature"},
+	"RowAccessPolicy": {"argument": "sdk.TableColumnSignature"},
 }

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates.go
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates.go
@@ -37,6 +37,7 @@ var (
 		genhelpers.FirstLetter,
 		genhelpers.SnakeCaseToCamel,
 		genhelpers.RemoveForbiddenAttributeNameSuffix,
+		genhelpers.ShouldGenerateWithForAttributeType,
 	)).Parse(buildersTemplateContent)
 
 	AllTemplates = []*template.Template{PreambleTemplate, DefinitionTemplate, MarshalJsonTemplate, BuildersTemplate}

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
@@ -10,7 +10,7 @@
 {{ range .Attributes -}}
     {{- $attributeNameCamel := SnakeCaseToCamel .Name -}}
     {{- $attributeNameWithoutForbiddenAttributeNameSuffix := RemoveForbiddenAttributeNameSuffix $attributeNameCamel -}}
-    {{ if .AttributeType }}
+    {{ if ShouldGenerateWithForAttributeType .AttributeType }}
         func ({{ $modelVar }} *{{ $modelName }}) With{{ $attributeNameWithoutForbiddenAttributeNameSuffix }}({{ FirstLetterLowercase $attributeNameCamel }} {{ .AttributeType }}) *{{ $modelName }} {
             {{ $modelVar }}.{{ $attributeNameCamel }} = {{ .MethodImport }}.{{ .VariableMethod }}({{ FirstLetterLowercase $attributeNameCamel }})
             return {{ $modelVar }}

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/builders.tmpl
@@ -10,7 +10,7 @@
 {{ range .Attributes -}}
     {{- $attributeNameCamel := SnakeCaseToCamel .Name -}}
     {{- $attributeNameWithoutForbiddenAttributeNameSuffix := RemoveForbiddenAttributeNameSuffix $attributeNameCamel -}}
-    {{ if ShouldGenerateWithForAttributeType .AttributeType }}
+    {{ if ShouldGenerateWithForAttributeType .OriginalType }}
         func ({{ $modelVar }} *{{ $modelName }}) With{{ $attributeNameWithoutForbiddenAttributeNameSuffix }}({{ FirstLetterLowercase $attributeNameCamel }} {{ .AttributeType }}) *{{ $modelName }} {
             {{ $modelVar }}.{{ $attributeNameCamel }} = {{ .MethodImport }}.{{ .VariableMethod }}({{ FirstLetterLowercase $attributeNameCamel }})
             return {{ $modelVar }}

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/preamble.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/preamble.tmpl
@@ -13,4 +13,7 @@ import (
 
     "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
     "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
+    {{- range .AdditionalImports }}
+    "{{- . }}"
+    {{- end }}
 )

--- a/pkg/datasources/security_integrations_acceptance_test.go
+++ b/pkg/datasources/security_integrations_acceptance_test.go
@@ -252,7 +252,7 @@ func TestAcc_SecurityIntegrations_ExternalOauth(t *testing.T) {
 	mappingAttribute := random.AlphaN(6)
 	audience := random.AlphaN(6)
 
-	resourceModel := model.ExternalOauthSecurityIntegration("test", true, issuer, string(sdk.ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeEmailAddress), claim, string(sdk.ExternalOauthSecurityIntegrationTypeCustom), id.Name()).
+	resourceModel := model.ExternalOauthSecurityIntegration("test", true, issuer, string(sdk.ExternalOauthSecurityIntegrationSnowflakeUserMappingAttributeEmailAddress), []string{claim}, string(sdk.ExternalOauthSecurityIntegrationTypeCustom), id.Name()).
 		WithComment(comment).
 		WithExternalOauthAllowedRoles(role.ID()).
 		WithExternalOauthAnyRoleMode(string(sdk.ExternalOauthSecurityIntegrationAnyRoleModeDisable)).

--- a/pkg/internal/genhelpers/resource_schema_details_extractor.go
+++ b/pkg/internal/genhelpers/resource_schema_details_extractor.go
@@ -16,26 +16,29 @@ func (s ResourceSchemaDetails) ObjectName() string {
 }
 
 type SchemaAttribute struct {
-	Name          string
-	AttributeType schema.ValueType
-	Required      bool
+	Name             string
+	AttributeType    schema.ValueType
+	AttributeSubType schema.ValueType
+	Required         bool
 }
 
 // TODO: test
-func ExtractResourceSchemaDetails(name string, schema map[string]*schema.Schema) ResourceSchemaDetails {
+func ExtractResourceSchemaDetails(name string, resourceSchema map[string]*schema.Schema) ResourceSchemaDetails {
 	orderedAttributeNames := make([]string, 0)
-	for key := range schema {
+	for key := range resourceSchema {
 		orderedAttributeNames = append(orderedAttributeNames, key)
 	}
 	slices.Sort(orderedAttributeNames)
 
 	attributes := make([]SchemaAttribute, 0)
 	for _, k := range orderedAttributeNames {
-		s := schema[k]
+		s := resourceSchema[k]
+		subtype := getComplexAttributeSubType(s)
 		attributes = append(attributes, SchemaAttribute{
-			Name:          k,
-			AttributeType: s.Type,
-			Required:      s.Required,
+			Name:             k,
+			AttributeType:    s.Type,
+			AttributeSubType: subtype,
+			Required:         s.Required,
 		})
 	}
 
@@ -43,4 +46,21 @@ func ExtractResourceSchemaDetails(name string, schema map[string]*schema.Schema)
 		Name:       name,
 		Attributes: attributes,
 	}
+}
+
+// getComplexAttributeSubType currently handles list/set of simple values and list/set of complex objects:
+// - simple: Elem: &schema.Schema{Type: schema.TypeString};
+// - complex: Elem: &schema.Resource{...};
+func getComplexAttributeSubType(s *schema.Schema) schema.ValueType {
+	if s.Type == schema.TypeList || s.Type == schema.TypeSet {
+		switch v := s.Elem.(type) {
+		case *schema.Schema:
+			return v.Type
+		case *schema.Resource:
+			return schema.TypeMap
+		default:
+			return schema.TypeInvalid
+		}
+	}
+	return s.Type
 }

--- a/pkg/internal/genhelpers/template_commons.go
+++ b/pkg/internal/genhelpers/template_commons.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // TODO [SNOW-1501905]: describe all methods in this file
@@ -51,6 +53,15 @@ func SnakeCaseToCamel(snake string) string {
 
 func RemoveForbiddenAttributeNameSuffix(input string) string {
 	return strings.TrimRight(input, forbiddenAttributeNameSuffix)
+}
+
+func ShouldGenerateWithForAttributeType(valueType schema.ValueType) bool {
+	switch valueType {
+	case schema.TypeBool, schema.TypeInt, schema.TypeFloat, schema.TypeString:
+		return true
+	default:
+		return false
+	}
 }
 
 func IsLastItem(itemIdx int, collectionLength int) bool {

--- a/pkg/internal/genhelpers/util.go
+++ b/pkg/internal/genhelpers/util.go
@@ -20,6 +20,10 @@ var (
 
 const forbiddenAttributeNameSuffix = "_"
 
+var PredefinedImports = map[string]string{
+	"sdk": "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk",
+}
+
 // ToSnakeCase allows converting a CamelCase text to camel_case one (needed for schema attribute names). Examples:
 // - CamelCase -> camel_case
 // - ACamelCase -> a_camel_case


### PR DESCRIPTION
Handle list and set required attributes, but ONLY in model builder constructors (`With` methods are still marked as non-generable).