### PR TITLE
fix: 3622 issue

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -18,6 +18,16 @@ across different versions.
 > [!TIP]
 > If you're still using the `Snowflake-Labs/snowflake` source, see [Upgrading from Snowflake-Labs Provider](./SNOWFLAKEDB_MIGRATION.md) to upgrade to the snowflakedb namespace.
 
+## v2.0.0 ➞ v2.0.1
+
+### *(bugfix)* Fixed `snowflake_tag_association` resource
+
+Reference: [#3622](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3622).
+
+The `snowflake_tag_association` resource was crashing for objects that are created on schema level.
+This was fixed, and now you can create tag associations for objects that are created on schema level, but
+we are advising to use the fields in target resources instead, e.g., `snowflake_table.tag`.
+
 ## v1.2.1 ➞ v2.0.0
 
 ### Supported architectures

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -22,11 +22,10 @@ across different versions.
 
 ### *(bugfix)* Fixed `snowflake_tag_association` resource
 
-Reference: [#3622](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3622).
+The `snowflake_tag_association` resource was crashing when performing the update operation (e.g., because the `tag_value` was changed)
+for objects that are created on schema level. This was fixed, and now you can create tag associations for objects that are created on schema level.
 
-The `snowflake_tag_association` resource was crashing for objects that are created on schema level.
-This was fixed, and now you can create tag associations for objects that are created on schema level, but
-we are advising to use the fields in target resources instead, e.g., `snowflake_table.tag`.
+Reference: [#3622](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3622).
 
 ## v1.2.1 ➞ v2.0.0
 

--- a/pkg/resources/tag_association.go
+++ b/pkg/resources/tag_association.go
@@ -219,12 +219,30 @@ func UpdateContextTagAssociation(ctx context.Context, d *schema.ResourceData, me
 		if err != nil {
 			return diag.FromErr(err)
 		}
+
 		newIds, err := ExpandObjectIdentifierSet(n.(*schema.Set).List(), objectType)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
-		addedIds, removedIds, commonIds := ListDiffWithCommonItems(oldIds, newIds)
+		oldIdsFQN := collections.Map(oldIds, sdk.ObjectIdentifier.FullyQualifiedName)
+		newIdsFQN := collections.Map(newIds, sdk.ObjectIdentifier.FullyQualifiedName)
+		addedIdsFQN, removedIdsFQN, commonIdsFQN := ListDiffWithCommonItems(oldIdsFQN, newIdsFQN)
+
+		addedIds, err := collections.MapErr(addedIdsFQN, sdk.ParseObjectIdentifierString)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		removedIds, err := collections.MapErr(removedIdsFQN, sdk.ParseObjectIdentifierString)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		commonIds, err := collections.MapErr(commonIdsFQN, sdk.ParseObjectIdentifierString)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
 		for _, id := range addedIds {
 			request := sdk.NewSetTagRequest(objectType, id).WithSetTags([]sdk.TagAssociation{

--- a/pkg/resources/tag_association_acceptance_test.go
+++ b/pkg/resources/tag_association_acceptance_test.go
@@ -687,3 +687,47 @@ resource "snowflake_tag_association" "test" {
 }
 `, tagId.DatabaseName(), tagId.SchemaName(), tagId.Name(), tagValue, sdk.ObjectTypeSchema, schemaId.DatabaseName(), schemaId.Name())
 }
+
+// proves https://github.com/snowflakedb/terraform-provider-snowflake/issues/3622 is fixed
+func TestAcc_TagAssociation_issue_3622(t *testing.T) {
+	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
+	acc.TestAccPreCheck(t)
+
+	tagId := acc.TestClient().Ids.RandomSchemaObjectIdentifier()
+	table, cleanupTable := acc.TestClient().Table.Create(t)
+	t.Cleanup(cleanupTable)
+	tagValue := "TAG_VALUE"
+	newTagValue := "NEW_TAG_VALUE"
+
+	tagModel := model.TagBase("test", tagId)
+	tagAssociationModel := model.TagAssociation("test", []sdk.ObjectIdentifier{table.ID()}, string(sdk.ObjectTypeTable), tagId.FullyQualifiedName(), tagValue).
+		WithDependsOn(tagModel.ResourceReference())
+	newTagAssociationModel := model.TagAssociation("test", []sdk.ObjectIdentifier{table.ID()}, string(sdk.ObjectTypeTable), tagId.FullyQualifiedName(), newTagValue).
+		WithDependsOn(tagModel.ResourceReference())
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: accconfig.FromModels(t, tagModel, tagAssociationModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "id", helpers.EncodeSnowflakeID(tagId.FullyQualifiedName(), tagValue, string(sdk.ObjectTypeTable))),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_value", tagValue),
+				),
+			},
+			{
+				// Couldn't assert it, but with `ExternalProviders: acc.ExternalProviderWithExactVersion("2.0.0")`,
+				// the plugin crashes with the same panic as in https://github.com/snowflakedb/terraform-provider-snowflake/issues/3622.
+				// The new version handles the SchemaObjectIdentifier correctly, so the panic is not triggered.
+				Config: accconfig.FromModels(t, tagModel, newTagAssociationModel),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "id", helpers.EncodeSnowflakeID(tagId.FullyQualifiedName(), tagValue, string(sdk.ObjectTypeTable))),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_value", newTagValue),
+				),
+			},
+		},
+	})
+}

--- a/pkg/resources/tag_association_acceptance_test.go
+++ b/pkg/resources/tag_association_acceptance_test.go
@@ -724,7 +724,7 @@ func TestAcc_TagAssociation_issue_3622(t *testing.T) {
 				// The new version handles the SchemaObjectIdentifier correctly, so the panic is not triggered.
 				Config: accconfig.FromModels(t, tagModel, newTagAssociationModel),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "id", helpers.EncodeSnowflakeID(tagId.FullyQualifiedName(), tagValue, string(sdk.ObjectTypeTable))),
+					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "id", helpers.EncodeSnowflakeID(tagId.FullyQualifiedName(), newTagValue, string(sdk.ObjectTypeTable))),
 					resource.TestCheckResourceAttr(tagAssociationModel.ResourceReference(), "tag_value", newTagValue),
 				),
 			},


### PR DESCRIPTION
## Changes
- Fixes the #3622 issue where tag association would fail for objects that use `sdk.SchemaObjectidentifier`, which is not a `comparable` type.
- The same error is expected to happen for `sdk.SchemaObjectIdentifierWithArguments`, but only functions and procedures use it, which don't support tagging (even if they would, we would wait for them to be implemented in the resource directly).