### PR TITLE
fix: object tracking

### DIFF
--- a/internal/tracking/version.go
+++ b/internal/tracking/version.go
@@ -5,7 +5,7 @@ import (
 	"log"
 )
 
-var ProviderVersion string
+var ProviderVersion = "dev"
 
 func SetProviderVersion(version string) {
 	providerVersion := fmt.Sprintf("v%s", version)

--- a/pkg/acceptance/helpers/information_schema_client.go
+++ b/pkg/acceptance/helpers/information_schema_client.go
@@ -35,8 +35,10 @@ type QueryHistory struct {
 
 func (c *InformationSchemaClient) GetQueryHistory(t *testing.T, limit int) []QueryHistory {
 	t.Helper()
+
 	result, err := c.client().QueryUnsafe(context.Background(), fmt.Sprintf("SELECT * FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(RESULT_LIMIT => %d))", limit))
 	require.NoError(t, err)
+
 	return collections.Map(result, func(queryResult map[string]*any) QueryHistory {
 		return c.mapQueryHistory(t, queryResult)
 	})
@@ -44,9 +46,11 @@ func (c *InformationSchemaClient) GetQueryHistory(t *testing.T, limit int) []Que
 
 func (c *InformationSchemaClient) GetQueryHistoryByQueryId(t *testing.T, limit int, queryId string) QueryHistory {
 	t.Helper()
+
 	result, err := c.client().QueryUnsafe(context.Background(), fmt.Sprintf("SELECT * FROM TABLE(INFORMATION_SCHEMA.QUERY_HISTORY(RESULT_LIMIT => %d)) WHERE QUERY_ID = '%s'", limit, queryId))
 	require.NoError(t, err)
 	require.Len(t, result, 1)
+
 	return c.mapQueryHistory(t, result[0])
 }
 

--- a/pkg/datasources/usage_tracking_acceptance_test.go
+++ b/pkg/datasources/usage_tracking_acceptance_test.go
@@ -3,6 +3,7 @@
 package datasources_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -35,10 +36,9 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 		WithInDatabase(schemaId.DatabaseId()).
 		WithDependsOn(schemaModel.ResourceReference())
 
-	assertQueryMetadataExists := func(t *testing.T, query string) resource.TestCheckFunc {
+	assertQueryMetadataExists := func(t *testing.T, queryHistory []helpers.QueryHistory, query string) resource.TestCheckFunc {
 		t.Helper()
 		return func(state *terraform.State) error {
-			queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 100)
 			expectedMetadata := tracking.NewVersionedDatasourceMetadata(datasources.Schemas)
 			if _, err := collections.FindFirst(queryHistory, func(history helpers.QueryHistory) bool {
 				metadata, err := tracking.ParseMetadata(history.QueryText)
@@ -62,12 +62,16 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 			{
 				Config: accconfig.FromModels(t, schemaModel, schemasModel),
 				Check: assertThat(t,
-					resourceassert.SchemaResource(t, schemaModel.ResourceReference()).
-						HasNameString(schemaId.Name()),
-					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`SHOW SCHEMAS LIKE '%s' IN DATABASE "%s"`, schemaId.Name(), schemaId.DatabaseName()))),
-					// SHOW PARAMETERS IN SCHEMA "acc_test_db_AT_1AB7E1DE_1A10_89C3_C13C_899754A250B6"."FPGDHEAT_1AB7E1DE_1A10_89C3_C13C_899754A250B6" --terraform_provider_usage_tracking {"json_schema_version":"1","version":"v0.99.0","datasource":"snowflake_schemas","operation":"read"}
-					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`SHOW PARAMETERS IN SCHEMA %s`, schemaId.FullyQualifiedName()))),
-					assert.Check(assertQueryMetadataExists(t, fmt.Sprintf(`DESCRIBE SCHEMA %s`, schemaId.FullyQualifiedName()))),
+					resourceassert.SchemaResource(t, schemaModel.ResourceReference()).HasNameString(schemaId.Name()),
+					assert.Check(func(state *terraform.State) error {
+						queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 100)
+						return errors.Join(
+							assertQueryMetadataExists(t, queryHistory, fmt.Sprintf(`SHOW SCHEMAS LIKE '%s' IN DATABASE "%s"`, schemaId.Name(), schemaId.DatabaseName()))(state),
+							// SHOW PARAMETERS IN SCHEMA "acc_test_db_AT_1AB7E1DE_1A10_89C3_C13C_899754A250B6"."FPGDHEAT_1AB7E1DE_1A10_89C3_C13C_899754A250B6" --terraform_provider_usage_tracking {"json_schema_version":"1","version":"v0.99.0","datasource":"snowflake_schemas","operation":"read"}
+							assertQueryMetadataExists(t, queryHistory, fmt.Sprintf(`SHOW PARAMETERS IN SCHEMA %s`, schemaId.FullyQualifiedName()))(state),
+							assertQueryMetadataExists(t, queryHistory, fmt.Sprintf(`DESCRIBE SCHEMA %s`, schemaId.FullyQualifiedName()))(state),
+						)
+					}),
 				),
 			},
 		},

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -3,6 +3,7 @@
 package resources_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -34,10 +35,9 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 	schemaModel := model.Schema("test", id.DatabaseName(), id.Name())
 	schemaModelWithComment := model.Schema("test", id.DatabaseName(), id.Name()).WithComment(comment)
 
-	assertQueryMetadataExists := func(t *testing.T, operation tracking.Operation, query string) resource.TestCheckFunc {
+	assertQueryMetadataExistsPrefetched := func(t *testing.T, queryHistory []helpers.QueryHistory, operation tracking.Operation, query string) resource.TestCheckFunc {
 		t.Helper()
 		return func(state *terraform.State) error {
-			queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 60)
 			expectedMetadata := tracking.NewVersionedResourceMetadata(resources.Schema, operation)
 			if _, err := collections.FindFirst(queryHistory, func(history helpers.QueryHistory) bool {
 				metadata, err := tracking.ParseMetadata(history.QueryText)
@@ -49,6 +49,12 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 			}
 			return nil
 		}
+	}
+
+	assertQueryMetadataExists := func(t *testing.T, operation tracking.Operation, query string) resource.TestCheckFunc {
+		t.Helper()
+		queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 100)
+		return assertQueryMetadataExistsPrefetched(t, queryHistory, operation, query)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -88,9 +94,14 @@ func TestAcc_CompleteUsageTracking(t *testing.T) {
 					resourceassert.SchemaResource(t, schemaModelWithComment.ResourceReference()).
 						HasNameString(id.Name()).
 						HasCommentString(comment),
-					assert.Check(assertQueryMetadataExists(t, tracking.UpdateOperation, fmt.Sprintf(`ALTER SCHEMA %s SET COMMENT = '%s'`, id.FullyQualifiedName(), comment))),
-					assert.Check(assertQueryMetadataExists(t, tracking.ReadOperation, fmt.Sprintf(`SHOW SCHEMAS LIKE '%s'`, id.Name()))),
-					assert.Check(assertQueryMetadataExists(t, tracking.CustomDiffOperation, fmt.Sprintf(`SHOW PARAMETERS IN SCHEMA %s`, id.FullyQualifiedName()))),
+					assert.Check(func(state *terraform.State) error {
+						queryHistory := acc.TestClient().InformationSchema.GetQueryHistory(t, 100)
+						return errors.Join(
+							assertQueryMetadataExistsPrefetched(t, queryHistory, tracking.UpdateOperation, fmt.Sprintf(`ALTER SCHEMA %s SET COMMENT = '%s'`, id.FullyQualifiedName(), comment))(state),
+							assertQueryMetadataExistsPrefetched(t, queryHistory, tracking.ReadOperation, fmt.Sprintf(`SHOW SCHEMAS LIKE '%s'`, id.Name()))(state),
+							assertQueryMetadataExistsPrefetched(t, queryHistory, tracking.CustomDiffOperation, fmt.Sprintf(`SHOW PARAMETERS IN SCHEMA %s`, id.FullyQualifiedName()))(state),
+						)
+					}),
 				),
 			},
 			// Delete

--- a/pkg/sdk/testint/authentication_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/authentication_policies_gen_integration_test.go
@@ -277,7 +277,7 @@ func TestInt_AuthenticationPolicies(t *testing.T) {
 		desc, err := client.AuthenticationPolicies.Describe(ctx, authenticationPolicy.ID())
 		require.NoError(t, err)
 
-		assert.GreaterOrEqual(t, 8, len(desc))
+		assert.GreaterOrEqual(t, len(desc), 9)
 		assert.Contains(t, desc, sdk.AuthenticationPolicyDescription{
 			Property:    "COMMENT",
 			Value:       "some_comment",


### PR DESCRIPTION
## Changes
- Set default tracking version to "dev", so that
  - a) We can track queries run by CI or us (dev team) locally.
  - b) We can keep the existing tracking logic (the tests were failing because of the internal validation that expects non-empty provider version and returns empty Metadata)
- Increase the limit to 100 (as sometimes we could observe tests failing because of other CI test jobs running simultaneously)