### PR TITLE
fix: Correct error handling in CreateContextExternalVolume function

### DIFF
--- a/pkg/resources/external_volume.go
+++ b/pkg/resources/external_volume.go
@@ -219,9 +219,9 @@ func CreateContextExternalVolume(ctx context.Context, d *schema.ResourceData, me
 		req.WithAllowWrites(parsed)
 	}
 
-	createErr := client.ExternalVolumes.Create(ctx, req)
+	err = client.ExternalVolumes.Create(ctx, req)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("error creating external volume %v err = %w", id.Name(), createErr))
+		return diag.FromErr(fmt.Errorf("error creating external volume %v err = %w", id.Name(), err))
 	}
 
 	d.SetId(helpers.EncodeResourceIdentifier(id))


### PR DESCRIPTION
## Summary

This PR fixes a variable name inconsistency in the external volume creation error handling logic. 
The code was using err in the condition check while storing the error in createErr, which would always result in the condition being false, preventing proper error reporting.