### PR TITLE
fix: Set value into correct field for field transformers

### DIFF
--- a/pkg/sdk/poc/generator/field_transformers.go
+++ b/pkg/sdk/poc/generator/field_transformers.go
@@ -135,12 +135,12 @@ func (v *ParameterTransformer) DoubleQuotes() *ParameterTransformer {
 }
 
 func (v *ParameterTransformer) NoParentheses() *ParameterTransformer {
-	v.quotes = "no_parentheses"
+	v.parentheses = "no_parentheses"
 	return v
 }
 
 func (v *ParameterTransformer) Parentheses() *ParameterTransformer {
-	v.quotes = "parentheses"
+	v.parentheses = "parentheses"
 	return v
 }
 
@@ -194,7 +194,7 @@ func (v *ListTransformer) NoEquals() *ListTransformer {
 }
 
 func (v *ListTransformer) NoComma() *ListTransformer {
-	v.equals = "no_comma"
+	v.comma = "no_comma"
 	return v
 }
 

--- a/pkg/sdk/secrets_gen.go
+++ b/pkg/sdk/secrets_gen.go
@@ -49,8 +49,8 @@ type CreateWithOAuthAuthorizationCodeFlowSecretOptions struct {
 	IfNotExists                 *bool                   `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name                        SchemaObjectIdentifier  `ddl:"identifier"`
 	secretType                  string                  `ddl:"static" sql:"TYPE = OAUTH2"`
-	OauthRefreshToken           string                  `ddl:"parameter,single_quotes" sql:"OAUTH_REFRESH_TOKEN"`
-	OauthRefreshTokenExpiryTime string                  `ddl:"parameter,single_quotes" sql:"OAUTH_REFRESH_TOKEN_EXPIRY_TIME"`
+	OauthRefreshToken           string                  `ddl:"parameter,single_quotes,no_parentheses" sql:"OAUTH_REFRESH_TOKEN"`
+	OauthRefreshTokenExpiryTime string                  `ddl:"parameter,single_quotes,no_parentheses" sql:"OAUTH_REFRESH_TOKEN_EXPIRY_TIME"`
 	ApiIntegration              AccountObjectIdentifier `ddl:"identifier,equals" sql:"API_AUTHENTICATION"`
 	Comment                     *string                 `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
@@ -63,8 +63,8 @@ type CreateWithBasicAuthenticationSecretOptions struct {
 	IfNotExists *bool                  `ddl:"keyword" sql:"IF NOT EXISTS"`
 	name        SchemaObjectIdentifier `ddl:"identifier"`
 	secretType  string                 `ddl:"static" sql:"TYPE = PASSWORD"`
-	Username    string                 `ddl:"parameter,single_quotes" sql:"USERNAME"`
-	Password    string                 `ddl:"parameter,single_quotes" sql:"PASSWORD"`
+	Username    string                 `ddl:"parameter,single_quotes,no_parentheses" sql:"USERNAME"`
+	Password    string                 `ddl:"parameter,single_quotes,no_parentheses" sql:"PASSWORD"`
 	Comment     *string                `ddl:"parameter,single_quotes" sql:"COMMENT"`
 }
 
@@ -178,6 +178,7 @@ type DescribeSecretOptions struct {
 	secret   bool                   `ddl:"static" sql:"SECRET"`
 	name     SchemaObjectIdentifier `ddl:"identifier"`
 }
+
 type secretDetailsDBRow struct {
 	CreatedOn                   time.Time      `db:"created_on"`
 	Name                        string         `db:"name"`
@@ -192,6 +193,7 @@ type secretDetailsDBRow struct {
 	OauthScopes                 sql.NullString `db:"oauth_scopes"`
 	IntegrationName             sql.NullString `db:"integration_name"`
 }
+
 type SecretDetails struct {
 	CreatedOn                   time.Time
 	Name                        string


### PR DESCRIPTION
This PR fixes an issue in the field transformers where certain fields were not being correctly assigned when set ddl options.  
The bug specifically affected cases where both `equals` and `parentheses` were set on a field.

The only affected case found was in `secrets_def.go`, so the DDL was regenerated for that file using the SDK.


## Test Plan
* [x] integration tests for `secrets_gen.go`

