### PR TITLE
refactor: Remove unused import in usage tracking acceptance test

### DIFF
--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAcc_CompleteUsageTracking(t *testing.T) {


### PR DESCRIPTION
Removed a duplicated import that was causing `make pre-push` to fail.

## Test Plan
* [x] acceptance tests

