### PR TITLE
fix: Generate dynamic blocks for all resource model builders

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/model/account_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/account_model_gen.go
@@ -29,6 +29,8 @@ type AccountModel struct {
 	Region             tfconfig.Variable `json:"region,omitempty"`
 	RegionGroup        tfconfig.Variable `json:"region_group,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -69,9 +71,9 @@ func AccountWithDefaultMeta(
 	return a
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (a *AccountModel) MarshalJSON() ([]byte, error) {
 	type Alias AccountModel
@@ -86,6 +88,11 @@ func (a *AccountModel) MarshalJSON() ([]byte, error) {
 
 func (a *AccountModel) WithDependsOn(values ...string) *AccountModel {
 	a.SetDependsOn(values...)
+	return a
+}
+
+func (a *AccountModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *AccountModel {
+	a.DynamicBlock = dynamicBlock
 	return a
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/account_parameter_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/account_parameter_model_gen.go
@@ -15,6 +15,8 @@ type AccountParameterModel struct {
 	Key   tfconfig.Variable `json:"key,omitempty"`
 	Value tfconfig.Variable `json:"value,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -43,9 +45,9 @@ func AccountParameterWithDefaultMeta(
 	return a
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (a *AccountParameterModel) MarshalJSON() ([]byte, error) {
 	type Alias AccountParameterModel
@@ -60,6 +62,11 @@ func (a *AccountParameterModel) MarshalJSON() ([]byte, error) {
 
 func (a *AccountParameterModel) WithDependsOn(values ...string) *AccountParameterModel {
 	a.SetDependsOn(values...)
+	return a
+}
+
+func (a *AccountParameterModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *AccountParameterModel {
+	a.DynamicBlock = dynamicBlock
 	return a
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/account_role_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/account_role_model_gen.go
@@ -16,6 +16,8 @@ type AccountRoleModel struct {
 	Comment            tfconfig.Variable `json:"comment,omitempty"`
 	FullyQualifiedName tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -40,9 +42,9 @@ func AccountRoleWithDefaultMeta(
 	return a
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (a *AccountRoleModel) MarshalJSON() ([]byte, error) {
 	type Alias AccountRoleModel
@@ -57,6 +59,11 @@ func (a *AccountRoleModel) MarshalJSON() ([]byte, error) {
 
 func (a *AccountRoleModel) WithDependsOn(values ...string) *AccountRoleModel {
 	a.SetDependsOn(values...)
+	return a
+}
+
+func (a *AccountRoleModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *AccountRoleModel {
+	a.DynamicBlock = dynamicBlock
 	return a
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/api_authentication_integration_with_authorization_code_grant_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/api_authentication_integration_with_authorization_code_grant_model_gen.go
@@ -25,6 +25,8 @@ type ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel struct {
 	OauthRefreshTokenValidity  tfconfig.Variable `json:"oauth_refresh_token_validity,omitempty"`
 	OauthTokenEndpoint         tfconfig.Variable `json:"oauth_token_endpoint,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -61,9 +63,9 @@ func ApiAuthenticationIntegrationWithAuthorizationCodeGrantWithDefaultMeta(
 	return a
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (a *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel) MarshalJSON() ([]byte, error) {
 	type Alias ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel
@@ -78,6 +80,11 @@ func (a *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel) MarshalJSO
 
 func (a *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel) WithDependsOn(values ...string) *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel {
 	a.SetDependsOn(values...)
+	return a
+}
+
+func (a *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ApiAuthenticationIntegrationWithAuthorizationCodeGrantModel {
+	a.DynamicBlock = dynamicBlock
 	return a
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/api_authentication_integration_with_client_credentials_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/api_authentication_integration_with_client_credentials_model_gen.go
@@ -24,6 +24,8 @@ type ApiAuthenticationIntegrationWithClientCredentialsModel struct {
 	OauthRefreshTokenValidity tfconfig.Variable `json:"oauth_refresh_token_validity,omitempty"`
 	OauthTokenEndpoint        tfconfig.Variable `json:"oauth_token_endpoint,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -60,9 +62,9 @@ func ApiAuthenticationIntegrationWithClientCredentialsWithDefaultMeta(
 	return a
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (a *ApiAuthenticationIntegrationWithClientCredentialsModel) MarshalJSON() ([]byte, error) {
 	type Alias ApiAuthenticationIntegrationWithClientCredentialsModel
@@ -77,6 +79,11 @@ func (a *ApiAuthenticationIntegrationWithClientCredentialsModel) MarshalJSON() (
 
 func (a *ApiAuthenticationIntegrationWithClientCredentialsModel) WithDependsOn(values ...string) *ApiAuthenticationIntegrationWithClientCredentialsModel {
 	a.SetDependsOn(values...)
+	return a
+}
+
+func (a *ApiAuthenticationIntegrationWithClientCredentialsModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ApiAuthenticationIntegrationWithClientCredentialsModel {
+	a.DynamicBlock = dynamicBlock
 	return a
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/database_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/database_model_gen.go
@@ -35,6 +35,8 @@ type DatabaseModel struct {
 	UserTaskMinimumTriggerIntervalInSeconds tfconfig.Variable `json:"user_task_minimum_trigger_interval_in_seconds,omitempty"`
 	UserTaskTimeoutMs                       tfconfig.Variable `json:"user_task_timeout_ms,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -59,9 +61,9 @@ func DatabaseWithDefaultMeta(
 	return d
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (d *DatabaseModel) MarshalJSON() ([]byte, error) {
 	type Alias DatabaseModel
@@ -76,6 +78,11 @@ func (d *DatabaseModel) MarshalJSON() ([]byte, error) {
 
 func (d *DatabaseModel) WithDependsOn(values ...string) *DatabaseModel {
 	d.SetDependsOn(values...)
+	return d
+}
+
+func (d *DatabaseModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *DatabaseModel {
+	d.DynamicBlock = dynamicBlock
 	return d
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/database_role_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/database_role_model_gen.go
@@ -17,6 +17,8 @@ type DatabaseRoleModel struct {
 	Comment            tfconfig.Variable `json:"comment,omitempty"`
 	FullyQualifiedName tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -45,9 +47,9 @@ func DatabaseRoleWithDefaultMeta(
 	return d
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (d *DatabaseRoleModel) MarshalJSON() ([]byte, error) {
 	type Alias DatabaseRoleModel
@@ -62,6 +64,11 @@ func (d *DatabaseRoleModel) MarshalJSON() ([]byte, error) {
 
 func (d *DatabaseRoleModel) WithDependsOn(values ...string) *DatabaseRoleModel {
 	d.SetDependsOn(values...)
+	return d
+}
+
+func (d *DatabaseRoleModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *DatabaseRoleModel {
+	d.DynamicBlock = dynamicBlock
 	return d
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/external_oauth_security_integration_model_gen.go
@@ -31,6 +31,8 @@ type ExternalOauthSecurityIntegrationModel struct {
 	FullyQualifiedName                         tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	RelatedParameters                          tfconfig.Variable `json:"related_parameters,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -75,9 +77,9 @@ func ExternalOauthSecurityIntegrationWithDefaultMeta(
 	return e
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (e *ExternalOauthSecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 	type Alias ExternalOauthSecurityIntegrationModel
@@ -92,6 +94,11 @@ func (e *ExternalOauthSecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 
 func (e *ExternalOauthSecurityIntegrationModel) WithDependsOn(values ...string) *ExternalOauthSecurityIntegrationModel {
 	e.SetDependsOn(values...)
+	return e
+}
+
+func (e *ExternalOauthSecurityIntegrationModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ExternalOauthSecurityIntegrationModel {
+	e.DynamicBlock = dynamicBlock
 	return e
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_java_model_gen.go
@@ -36,6 +36,8 @@ type FunctionJavaModel struct {
 	TargetPath                 tfconfig.Variable `json:"target_path,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -76,9 +78,9 @@ func FunctionJavaWithDefaultMeta(
 	return f
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
 	type Alias FunctionJavaModel
@@ -93,6 +95,11 @@ func (f *FunctionJavaModel) MarshalJSON() ([]byte, error) {
 
 func (f *FunctionJavaModel) WithDependsOn(values ...string) *FunctionJavaModel {
 	f.SetDependsOn(values...)
+	return f
+}
+
+func (f *FunctionJavaModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *FunctionJavaModel {
+	f.DynamicBlock = dynamicBlock
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_javascript_model_gen.go
@@ -29,6 +29,8 @@ type FunctionJavascriptModel struct {
 	ReturnType            tfconfig.Variable `json:"return_type,omitempty"`
 	TraceLevel            tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -69,9 +71,9 @@ func FunctionJavascriptWithDefaultMeta(
 	return f
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (f *FunctionJavascriptModel) MarshalJSON() ([]byte, error) {
 	type Alias FunctionJavascriptModel
@@ -86,6 +88,11 @@ func (f *FunctionJavascriptModel) MarshalJSON() ([]byte, error) {
 
 func (f *FunctionJavascriptModel) WithDependsOn(values ...string) *FunctionJavascriptModel {
 	f.SetDependsOn(values...)
+	return f
+}
+
+func (f *FunctionJavascriptModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *FunctionJavascriptModel {
+	f.DynamicBlock = dynamicBlock
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_python_model_gen.go
@@ -36,6 +36,8 @@ type FunctionPythonModel struct {
 	Secrets                    tfconfig.Variable `json:"secrets,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -80,9 +82,9 @@ func FunctionPythonWithDefaultMeta(
 	return f
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (f *FunctionPythonModel) MarshalJSON() ([]byte, error) {
 	type Alias FunctionPythonModel
@@ -97,6 +99,11 @@ func (f *FunctionPythonModel) MarshalJSON() ([]byte, error) {
 
 func (f *FunctionPythonModel) WithDependsOn(values ...string) *FunctionPythonModel {
 	f.SetDependsOn(values...)
+	return f
+}
+
+func (f *FunctionPythonModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *FunctionPythonModel {
+	f.DynamicBlock = dynamicBlock
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_scala_model_gen.go
@@ -36,6 +36,8 @@ type FunctionScalaModel struct {
 	TargetPath                 tfconfig.Variable `json:"target_path,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -80,9 +82,9 @@ func FunctionScalaWithDefaultMeta(
 	return f
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (f *FunctionScalaModel) MarshalJSON() ([]byte, error) {
 	type Alias FunctionScalaModel
@@ -97,6 +99,11 @@ func (f *FunctionScalaModel) MarshalJSON() ([]byte, error) {
 
 func (f *FunctionScalaModel) WithDependsOn(values ...string) *FunctionScalaModel {
 	f.SetDependsOn(values...)
+	return f
+}
+
+func (f *FunctionScalaModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *FunctionScalaModel {
+	f.DynamicBlock = dynamicBlock
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/function_sql_model_gen.go
@@ -28,6 +28,8 @@ type FunctionSqlModel struct {
 	ReturnType            tfconfig.Variable `json:"return_type,omitempty"`
 	TraceLevel            tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -68,9 +70,9 @@ func FunctionSqlWithDefaultMeta(
 	return f
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (f *FunctionSqlModel) MarshalJSON() ([]byte, error) {
 	type Alias FunctionSqlModel
@@ -85,6 +87,11 @@ func (f *FunctionSqlModel) MarshalJSON() ([]byte, error) {
 
 func (f *FunctionSqlModel) WithDependsOn(values ...string) *FunctionSqlModel {
 	f.SetDependsOn(values...)
+	return f
+}
+
+func (f *FunctionSqlModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *FunctionSqlModel {
+	f.DynamicBlock = dynamicBlock
 	return f
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/definition.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/definition.tmpl
@@ -8,6 +8,8 @@ type {{ $modelName }} struct {
     {{ range .Attributes -}}
         {{ SnakeCaseToCamel .Name }} tfconfig.Variable `json:"{{ .JsonName }},omitempty"`
     {{ end }}
+    DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
     *config.ResourceModelMeta
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/gen/templates/marshal_json.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/model/gen/templates/marshal_json.tmpl
@@ -3,9 +3,9 @@
 {{- $modelName := .Name | printf "%sModel" -}}
 {{- $nameLowerCase := FirstLetterLowercase .Name -}}
 {{- $modelVar := FirstLetter $nameLowerCase }}
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func ({{ $modelVar }} *{{ $modelName }}) MarshalJSON() ([]byte, error) {
     type Alias {{ $modelName }}
@@ -20,5 +20,10 @@ func ({{ $modelVar }} *{{ $modelName }}) MarshalJSON() ([]byte, error) {
 
 func ({{ $modelVar }} *{{ $modelName }}) WithDependsOn(values ...string) *{{ $modelName }} {
     {{ $modelVar }}.SetDependsOn(values...)
+    return {{ $modelVar }}
+}
+
+func ({{ $modelVar }} *{{ $modelName }}) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *{{ $modelName }} {
+    {{ $modelVar }}.DynamicBlock = dynamicBlock
     return {{ $modelVar }}
 }

--- a/pkg/acceptance/bettertestspoc/config/model/legacy_service_user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/legacy_service_user_model_gen.go
@@ -89,6 +89,8 @@ type LegacyServiceUserModel struct {
 	WeekOfYearPolicy                         tfconfig.Variable `json:"week_of_year_policy,omitempty"`
 	WeekStart                                tfconfig.Variable `json:"week_start,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -113,9 +115,9 @@ func LegacyServiceUserWithDefaultMeta(
 	return l
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (l *LegacyServiceUserModel) MarshalJSON() ([]byte, error) {
 	type Alias LegacyServiceUserModel
@@ -130,6 +132,11 @@ func (l *LegacyServiceUserModel) MarshalJSON() ([]byte, error) {
 
 func (l *LegacyServiceUserModel) WithDependsOn(values ...string) *LegacyServiceUserModel {
 	l.SetDependsOn(values...)
+	return l
+}
+
+func (l *LegacyServiceUserModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *LegacyServiceUserModel {
+	l.DynamicBlock = dynamicBlock
 	return l
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/managed_account_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/managed_account_model_gen.go
@@ -24,6 +24,8 @@ type ManagedAccountModel struct {
 	Type_              tfconfig.Variable `json:"type,omitempty"`
 	Url                tfconfig.Variable `json:"url,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -56,9 +58,9 @@ func ManagedAccountWithDefaultMeta(
 	return m
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (m *ManagedAccountModel) MarshalJSON() ([]byte, error) {
 	type Alias ManagedAccountModel
@@ -73,6 +75,11 @@ func (m *ManagedAccountModel) MarshalJSON() ([]byte, error) {
 
 func (m *ManagedAccountModel) WithDependsOn(values ...string) *ManagedAccountModel {
 	m.SetDependsOn(values...)
+	return m
+}
+
+func (m *ManagedAccountModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ManagedAccountModel {
+	m.DynamicBlock = dynamicBlock
 	return m
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/masking_policy_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/masking_policy_model_gen.go
@@ -23,7 +23,6 @@ type MaskingPolicyModel struct {
 	FullyQualifiedName  tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	ReturnDataType      tfconfig.Variable `json:"return_data_type,omitempty"`
 
-	// added manually as a PoC
 	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
 
 	*config.ResourceModelMeta
@@ -70,9 +69,9 @@ func MaskingPolicyWithDefaultMeta(
 	return m
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (m *MaskingPolicyModel) MarshalJSON() ([]byte, error) {
 	type Alias MaskingPolicyModel
@@ -90,7 +89,6 @@ func (m *MaskingPolicyModel) WithDependsOn(values ...string) *MaskingPolicyModel
 	return m
 }
 
-// added manually as a PoC
 func (m *MaskingPolicyModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *MaskingPolicyModel {
 	m.DynamicBlock = dynamicBlock
 	return m

--- a/pkg/acceptance/bettertestspoc/config/model/network_policy_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/network_policy_model_gen.go
@@ -20,6 +20,8 @@ type NetworkPolicyModel struct {
 	Comment                tfconfig.Variable `json:"comment,omitempty"`
 	FullyQualifiedName     tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -44,9 +46,9 @@ func NetworkPolicyWithDefaultMeta(
 	return n
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (n *NetworkPolicyModel) MarshalJSON() ([]byte, error) {
 	type Alias NetworkPolicyModel
@@ -61,6 +63,11 @@ func (n *NetworkPolicyModel) MarshalJSON() ([]byte, error) {
 
 func (n *NetworkPolicyModel) WithDependsOn(values ...string) *NetworkPolicyModel {
 	n.SetDependsOn(values...)
+	return n
+}
+
+func (n *NetworkPolicyModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *NetworkPolicyModel {
+	n.DynamicBlock = dynamicBlock
 	return n
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/oauth_integration_for_custom_clients_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/oauth_integration_for_custom_clients_model_gen.go
@@ -30,6 +30,8 @@ type OauthIntegrationForCustomClientsModel struct {
 	PreAuthorizedRolesList      tfconfig.Variable `json:"pre_authorized_roles_list,omitempty"`
 	RelatedParameters           tfconfig.Variable `json:"related_parameters,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -62,9 +64,9 @@ func OauthIntegrationForCustomClientsWithDefaultMeta(
 	return o
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (o *OauthIntegrationForCustomClientsModel) MarshalJSON() ([]byte, error) {
 	type Alias OauthIntegrationForCustomClientsModel
@@ -79,6 +81,11 @@ func (o *OauthIntegrationForCustomClientsModel) MarshalJSON() ([]byte, error) {
 
 func (o *OauthIntegrationForCustomClientsModel) WithDependsOn(values ...string) *OauthIntegrationForCustomClientsModel {
 	o.SetDependsOn(values...)
+	return o
+}
+
+func (o *OauthIntegrationForCustomClientsModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *OauthIntegrationForCustomClientsModel {
+	o.DynamicBlock = dynamicBlock
 	return o
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/oauth_integration_for_partner_applications_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/oauth_integration_for_partner_applications_model_gen.go
@@ -24,6 +24,8 @@ type OauthIntegrationForPartnerApplicationsModel struct {
 	OauthUseSecondaryRoles    tfconfig.Variable `json:"oauth_use_secondary_roles,omitempty"`
 	RelatedParameters         tfconfig.Variable `json:"related_parameters,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -52,9 +54,9 @@ func OauthIntegrationForPartnerApplicationsWithDefaultMeta(
 	return o
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (o *OauthIntegrationForPartnerApplicationsModel) MarshalJSON() ([]byte, error) {
 	type Alias OauthIntegrationForPartnerApplicationsModel
@@ -69,6 +71,11 @@ func (o *OauthIntegrationForPartnerApplicationsModel) MarshalJSON() ([]byte, err
 
 func (o *OauthIntegrationForPartnerApplicationsModel) WithDependsOn(values ...string) *OauthIntegrationForPartnerApplicationsModel {
 	o.SetDependsOn(values...)
+	return o
+}
+
+func (o *OauthIntegrationForPartnerApplicationsModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *OauthIntegrationForPartnerApplicationsModel {
+	o.DynamicBlock = dynamicBlock
 	return o
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/primary_connection_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/primary_connection_model_gen.go
@@ -18,6 +18,8 @@ type PrimaryConnectionModel struct {
 	FullyQualifiedName       tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	IsPrimary                tfconfig.Variable `json:"is_primary,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -42,9 +44,9 @@ func PrimaryConnectionWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *PrimaryConnectionModel) MarshalJSON() ([]byte, error) {
 	type Alias PrimaryConnectionModel
@@ -59,6 +61,11 @@ func (p *PrimaryConnectionModel) MarshalJSON() ([]byte, error) {
 
 func (p *PrimaryConnectionModel) WithDependsOn(values ...string) *PrimaryConnectionModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *PrimaryConnectionModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *PrimaryConnectionModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_java_model_gen.go
@@ -37,6 +37,8 @@ type ProcedureJavaModel struct {
 	TargetPath                 tfconfig.Variable `json:"target_path,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -85,9 +87,9 @@ func ProcedureJavaWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *ProcedureJavaModel) MarshalJSON() ([]byte, error) {
 	type Alias ProcedureJavaModel
@@ -102,6 +104,11 @@ func (p *ProcedureJavaModel) MarshalJSON() ([]byte, error) {
 
 func (p *ProcedureJavaModel) WithDependsOn(values ...string) *ProcedureJavaModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *ProcedureJavaModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ProcedureJavaModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_javascript_model_gen.go
@@ -29,6 +29,8 @@ type ProcedureJavascriptModel struct {
 	ReturnType          tfconfig.Variable `json:"return_type,omitempty"`
 	TraceLevel          tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -69,9 +71,9 @@ func ProcedureJavascriptWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *ProcedureJavascriptModel) MarshalJSON() ([]byte, error) {
 	type Alias ProcedureJavascriptModel
@@ -86,6 +88,11 @@ func (p *ProcedureJavascriptModel) MarshalJSON() ([]byte, error) {
 
 func (p *ProcedureJavascriptModel) WithDependsOn(values ...string) *ProcedureJavascriptModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *ProcedureJavascriptModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ProcedureJavascriptModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_gen.go
@@ -36,6 +36,8 @@ type ProcedurePythonModel struct {
 	SnowparkPackage            tfconfig.Variable `json:"snowpark_package,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -84,9 +86,9 @@ func ProcedurePythonWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *ProcedurePythonModel) MarshalJSON() ([]byte, error) {
 	type Alias ProcedurePythonModel
@@ -101,6 +103,11 @@ func (p *ProcedurePythonModel) MarshalJSON() ([]byte, error) {
 
 func (p *ProcedurePythonModel) WithDependsOn(values ...string) *ProcedurePythonModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *ProcedurePythonModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ProcedurePythonModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_scala_model_gen.go
@@ -37,6 +37,8 @@ type ProcedureScalaModel struct {
 	TargetPath                 tfconfig.Variable `json:"target_path,omitempty"`
 	TraceLevel                 tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -85,9 +87,9 @@ func ProcedureScalaWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *ProcedureScalaModel) MarshalJSON() ([]byte, error) {
 	type Alias ProcedureScalaModel
@@ -102,6 +104,11 @@ func (p *ProcedureScalaModel) MarshalJSON() ([]byte, error) {
 
 func (p *ProcedureScalaModel) WithDependsOn(values ...string) *ProcedureScalaModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *ProcedureScalaModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ProcedureScalaModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_sql_model_gen.go
@@ -29,6 +29,8 @@ type ProcedureSqlModel struct {
 	ReturnType          tfconfig.Variable `json:"return_type,omitempty"`
 	TraceLevel          tfconfig.Variable `json:"trace_level,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -69,9 +71,9 @@ func ProcedureSqlWithDefaultMeta(
 	return p
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (p *ProcedureSqlModel) MarshalJSON() ([]byte, error) {
 	type Alias ProcedureSqlModel
@@ -86,6 +88,11 @@ func (p *ProcedureSqlModel) MarshalJSON() ([]byte, error) {
 
 func (p *ProcedureSqlModel) WithDependsOn(values ...string) *ProcedureSqlModel {
 	p.SetDependsOn(values...)
+	return p
+}
+
+func (p *ProcedureSqlModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ProcedureSqlModel {
+	p.DynamicBlock = dynamicBlock
 	return p
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/resource_monitor_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/resource_monitor_model_gen.go
@@ -23,6 +23,8 @@ type ResourceMonitorModel struct {
 	SuspendImmediateTrigger tfconfig.Variable `json:"suspend_immediate_trigger,omitempty"`
 	SuspendTrigger          tfconfig.Variable `json:"suspend_trigger,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -47,9 +49,9 @@ func ResourceMonitorWithDefaultMeta(
 	return r
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (r *ResourceMonitorModel) MarshalJSON() ([]byte, error) {
 	type Alias ResourceMonitorModel
@@ -64,6 +66,11 @@ func (r *ResourceMonitorModel) MarshalJSON() ([]byte, error) {
 
 func (r *ResourceMonitorModel) WithDependsOn(values ...string) *ResourceMonitorModel {
 	r.SetDependsOn(values...)
+	return r
+}
+
+func (r *ResourceMonitorModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ResourceMonitorModel {
+	r.DynamicBlock = dynamicBlock
 	return r
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/row_access_policy_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/row_access_policy_model_ext.go
@@ -8,12 +8,6 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
-// added manually as a PoC
-func (r *RowAccessPolicyModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *RowAccessPolicyModel {
-	r.DynamicBlock = dynamicBlock
-	return r
-}
-
 func RowAccessPolicyDynamicArguments(
 	resourceName string,
 	id sdk.SchemaObjectIdentifier,

--- a/pkg/acceptance/bettertestspoc/config/model/row_access_policy_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/row_access_policy_model_gen.go
@@ -21,7 +21,6 @@ type RowAccessPolicyModel struct {
 	Comment            tfconfig.Variable `json:"comment,omitempty"`
 	FullyQualifiedName tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 
-	// added manually
 	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
 
 	*config.ResourceModelMeta
@@ -64,9 +63,9 @@ func RowAccessPolicyWithDefaultMeta(
 	return r
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (r *RowAccessPolicyModel) MarshalJSON() ([]byte, error) {
 	type Alias RowAccessPolicyModel
@@ -81,6 +80,11 @@ func (r *RowAccessPolicyModel) MarshalJSON() ([]byte, error) {
 
 func (r *RowAccessPolicyModel) WithDependsOn(values ...string) *RowAccessPolicyModel {
 	r.SetDependsOn(values...)
+	return r
+}
+
+func (r *RowAccessPolicyModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *RowAccessPolicyModel {
+	r.DynamicBlock = dynamicBlock
 	return r
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/saml2_security_integration_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/saml2_security_integration_model_gen.go
@@ -31,6 +31,8 @@ type Saml2SecurityIntegrationModel struct {
 	Saml2SsoUrl                    tfconfig.Variable `json:"saml2_sso_url,omitempty"`
 	Saml2X509Cert                  tfconfig.Variable `json:"saml2_x509_cert,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -71,9 +73,9 @@ func Saml2SecurityIntegrationWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *Saml2SecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 	type Alias Saml2SecurityIntegrationModel
@@ -88,6 +90,11 @@ func (s *Saml2SecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 
 func (s *Saml2SecurityIntegrationModel) WithDependsOn(values ...string) *Saml2SecurityIntegrationModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *Saml2SecurityIntegrationModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *Saml2SecurityIntegrationModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/schema_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/schema_model_gen.go
@@ -36,6 +36,8 @@ type SchemaModel struct {
 	UserTaskTimeoutMs                       tfconfig.Variable `json:"user_task_timeout_ms,omitempty"`
 	WithManagedAccess                       tfconfig.Variable `json:"with_managed_access,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -64,9 +66,9 @@ func SchemaWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SchemaModel) MarshalJSON() ([]byte, error) {
 	type Alias SchemaModel
@@ -81,6 +83,11 @@ func (s *SchemaModel) MarshalJSON() ([]byte, error) {
 
 func (s *SchemaModel) WithDependsOn(values ...string) *SchemaModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SchemaModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SchemaModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/scim_security_integration_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/scim_security_integration_model_gen.go
@@ -21,6 +21,8 @@ type ScimSecurityIntegrationModel struct {
 	ScimClient         tfconfig.Variable `json:"scim_client,omitempty"`
 	SyncPassword       tfconfig.Variable `json:"sync_password,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -57,9 +59,9 @@ func ScimSecurityIntegrationWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *ScimSecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 	type Alias ScimSecurityIntegrationModel
@@ -74,6 +76,11 @@ func (s *ScimSecurityIntegrationModel) MarshalJSON() ([]byte, error) {
 
 func (s *ScimSecurityIntegrationModel) WithDependsOn(values ...string) *ScimSecurityIntegrationModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *ScimSecurityIntegrationModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ScimSecurityIntegrationModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secondary_connection_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secondary_connection_model_gen.go
@@ -18,6 +18,8 @@ type SecondaryConnectionModel struct {
 	FullyQualifiedName tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	IsPrimary          tfconfig.Variable `json:"is_primary,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -46,9 +48,9 @@ func SecondaryConnectionWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecondaryConnectionModel) MarshalJSON() ([]byte, error) {
 	type Alias SecondaryConnectionModel
@@ -63,6 +65,11 @@ func (s *SecondaryConnectionModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecondaryConnectionModel) WithDependsOn(values ...string) *SecondaryConnectionModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecondaryConnectionModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecondaryConnectionModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secondary_database_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secondary_database_model_gen.go
@@ -34,6 +34,8 @@ type SecondaryDatabaseModel struct {
 	UserTaskMinimumTriggerIntervalInSeconds tfconfig.Variable `json:"user_task_minimum_trigger_interval_in_seconds,omitempty"`
 	UserTaskTimeoutMs                       tfconfig.Variable `json:"user_task_timeout_ms,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -62,9 +64,9 @@ func SecondaryDatabaseWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecondaryDatabaseModel) MarshalJSON() ([]byte, error) {
 	type Alias SecondaryDatabaseModel
@@ -79,6 +81,11 @@ func (s *SecondaryDatabaseModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecondaryDatabaseModel) WithDependsOn(values ...string) *SecondaryDatabaseModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecondaryDatabaseModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecondaryDatabaseModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secret_with_authorization_code_grant_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secret_with_authorization_code_grant_model_gen.go
@@ -22,6 +22,8 @@ type SecretWithAuthorizationCodeGrantModel struct {
 	OauthRefreshTokenExpiryTime tfconfig.Variable `json:"oauth_refresh_token_expiry_time,omitempty"`
 	SecretType                  tfconfig.Variable `json:"secret_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -66,9 +68,9 @@ func SecretWithAuthorizationCodeGrantWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecretWithAuthorizationCodeGrantModel) MarshalJSON() ([]byte, error) {
 	type Alias SecretWithAuthorizationCodeGrantModel
@@ -83,6 +85,11 @@ func (s *SecretWithAuthorizationCodeGrantModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecretWithAuthorizationCodeGrantModel) WithDependsOn(values ...string) *SecretWithAuthorizationCodeGrantModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecretWithAuthorizationCodeGrantModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecretWithAuthorizationCodeGrantModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secret_with_basic_authentication_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secret_with_basic_authentication_model_gen.go
@@ -21,6 +21,8 @@ type SecretWithBasicAuthenticationModel struct {
 	SecretType         tfconfig.Variable `json:"secret_type,omitempty"`
 	Username           tfconfig.Variable `json:"username,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -61,9 +63,9 @@ func SecretWithBasicAuthenticationWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecretWithBasicAuthenticationModel) MarshalJSON() ([]byte, error) {
 	type Alias SecretWithBasicAuthenticationModel
@@ -78,6 +80,11 @@ func (s *SecretWithBasicAuthenticationModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecretWithBasicAuthenticationModel) WithDependsOn(values ...string) *SecretWithBasicAuthenticationModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecretWithBasicAuthenticationModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecretWithBasicAuthenticationModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secret_with_client_credentials_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secret_with_client_credentials_model_gen.go
@@ -21,6 +21,8 @@ type SecretWithClientCredentialsModel struct {
 	OauthScopes        tfconfig.Variable `json:"oauth_scopes,omitempty"`
 	SecretType         tfconfig.Variable `json:"secret_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -61,9 +63,9 @@ func SecretWithClientCredentialsWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecretWithClientCredentialsModel) MarshalJSON() ([]byte, error) {
 	type Alias SecretWithClientCredentialsModel
@@ -78,6 +80,11 @@ func (s *SecretWithClientCredentialsModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecretWithClientCredentialsModel) WithDependsOn(values ...string) *SecretWithClientCredentialsModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecretWithClientCredentialsModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecretWithClientCredentialsModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/secret_with_generic_string_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/secret_with_generic_string_model_gen.go
@@ -20,6 +20,8 @@ type SecretWithGenericStringModel struct {
 	SecretString       tfconfig.Variable `json:"secret_string,omitempty"`
 	SecretType         tfconfig.Variable `json:"secret_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -56,9 +58,9 @@ func SecretWithGenericStringWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SecretWithGenericStringModel) MarshalJSON() ([]byte, error) {
 	type Alias SecretWithGenericStringModel
@@ -73,6 +75,11 @@ func (s *SecretWithGenericStringModel) MarshalJSON() ([]byte, error) {
 
 func (s *SecretWithGenericStringModel) WithDependsOn(values ...string) *SecretWithGenericStringModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SecretWithGenericStringModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SecretWithGenericStringModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/service_user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/service_user_model_gen.go
@@ -87,6 +87,8 @@ type ServiceUserModel struct {
 	WeekOfYearPolicy                         tfconfig.Variable `json:"week_of_year_policy,omitempty"`
 	WeekStart                                tfconfig.Variable `json:"week_start,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -111,9 +113,9 @@ func ServiceUserWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *ServiceUserModel) MarshalJSON() ([]byte, error) {
 	type Alias ServiceUserModel
@@ -128,6 +130,11 @@ func (s *ServiceUserModel) MarshalJSON() ([]byte, error) {
 
 func (s *ServiceUserModel) WithDependsOn(values ...string) *ServiceUserModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *ServiceUserModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ServiceUserModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/shared_database_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/shared_database_model_gen.go
@@ -31,6 +31,8 @@ type SharedDatabaseModel struct {
 	UserTaskMinimumTriggerIntervalInSeconds tfconfig.Variable `json:"user_task_minimum_trigger_interval_in_seconds,omitempty"`
 	UserTaskTimeoutMs                       tfconfig.Variable `json:"user_task_timeout_ms,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -59,9 +61,9 @@ func SharedDatabaseWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *SharedDatabaseModel) MarshalJSON() ([]byte, error) {
 	type Alias SharedDatabaseModel
@@ -76,6 +78,11 @@ func (s *SharedDatabaseModel) MarshalJSON() ([]byte, error) {
 
 func (s *SharedDatabaseModel) WithDependsOn(values ...string) *SharedDatabaseModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *SharedDatabaseModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *SharedDatabaseModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/stream_on_directory_table_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/stream_on_directory_table_model_gen.go
@@ -22,6 +22,8 @@ type StreamOnDirectoryTableModel struct {
 	Stale              tfconfig.Variable `json:"stale,omitempty"`
 	StreamType         tfconfig.Variable `json:"stream_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -58,9 +60,9 @@ func StreamOnDirectoryTableWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *StreamOnDirectoryTableModel) MarshalJSON() ([]byte, error) {
 	type Alias StreamOnDirectoryTableModel
@@ -75,6 +77,11 @@ func (s *StreamOnDirectoryTableModel) MarshalJSON() ([]byte, error) {
 
 func (s *StreamOnDirectoryTableModel) WithDependsOn(values ...string) *StreamOnDirectoryTableModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *StreamOnDirectoryTableModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *StreamOnDirectoryTableModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/stream_on_external_table_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/stream_on_external_table_model_gen.go
@@ -25,6 +25,8 @@ type StreamOnExternalTableModel struct {
 	Stale              tfconfig.Variable `json:"stale,omitempty"`
 	StreamType         tfconfig.Variable `json:"stream_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -61,9 +63,9 @@ func StreamOnExternalTableWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *StreamOnExternalTableModel) MarshalJSON() ([]byte, error) {
 	type Alias StreamOnExternalTableModel
@@ -78,6 +80,11 @@ func (s *StreamOnExternalTableModel) MarshalJSON() ([]byte, error) {
 
 func (s *StreamOnExternalTableModel) WithDependsOn(values ...string) *StreamOnExternalTableModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *StreamOnExternalTableModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *StreamOnExternalTableModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/stream_on_table_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/stream_on_table_model_gen.go
@@ -26,6 +26,8 @@ type StreamOnTableModel struct {
 	StreamType         tfconfig.Variable `json:"stream_type,omitempty"`
 	Table              tfconfig.Variable `json:"table,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -62,9 +64,9 @@ func StreamOnTableWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *StreamOnTableModel) MarshalJSON() ([]byte, error) {
 	type Alias StreamOnTableModel
@@ -79,6 +81,11 @@ func (s *StreamOnTableModel) MarshalJSON() ([]byte, error) {
 
 func (s *StreamOnTableModel) WithDependsOn(values ...string) *StreamOnTableModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *StreamOnTableModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *StreamOnTableModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/stream_on_view_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/stream_on_view_model_gen.go
@@ -26,6 +26,8 @@ type StreamOnViewModel struct {
 	StreamType         tfconfig.Variable `json:"stream_type,omitempty"`
 	View               tfconfig.Variable `json:"view,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -62,9 +64,9 @@ func StreamOnViewWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *StreamOnViewModel) MarshalJSON() ([]byte, error) {
 	type Alias StreamOnViewModel
@@ -79,6 +81,11 @@ func (s *StreamOnViewModel) MarshalJSON() ([]byte, error) {
 
 func (s *StreamOnViewModel) WithDependsOn(values ...string) *StreamOnViewModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *StreamOnViewModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *StreamOnViewModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/streamlit_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/streamlit_model_gen.go
@@ -24,6 +24,8 @@ type StreamlitModel struct {
 	Stage                      tfconfig.Variable `json:"stage,omitempty"`
 	Title                      tfconfig.Variable `json:"title,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -64,9 +66,9 @@ func StreamlitWithDefaultMeta(
 	return s
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (s *StreamlitModel) MarshalJSON() ([]byte, error) {
 	type Alias StreamlitModel
@@ -81,6 +83,11 @@ func (s *StreamlitModel) MarshalJSON() ([]byte, error) {
 
 func (s *StreamlitModel) WithDependsOn(values ...string) *StreamlitModel {
 	s.SetDependsOn(values...)
+	return s
+}
+
+func (s *StreamlitModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *StreamlitModel {
+	s.DynamicBlock = dynamicBlock
 	return s
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/table_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/table_model_gen.go
@@ -26,6 +26,8 @@ type TableModel struct {
 	PrimaryKey              tfconfig.Variable `json:"primary_key,omitempty"`
 	Tag                     tfconfig.Variable `json:"tag,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -62,9 +64,9 @@ func TableWithDefaultMeta(
 	return t
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (t *TableModel) MarshalJSON() ([]byte, error) {
 	type Alias TableModel
@@ -79,6 +81,11 @@ func (t *TableModel) MarshalJSON() ([]byte, error) {
 
 func (t *TableModel) WithDependsOn(values ...string) *TableModel {
 	t.SetDependsOn(values...)
+	return t
+}
+
+func (t *TableModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *TableModel {
+	t.DynamicBlock = dynamicBlock
 	return t
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/tag_association_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/tag_association_model_gen.go
@@ -19,6 +19,8 @@ type TagAssociationModel struct {
 	TagId             tfconfig.Variable `json:"tag_id,omitempty"`
 	TagValue          tfconfig.Variable `json:"tag_value,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -55,9 +57,9 @@ func TagAssociationWithDefaultMeta(
 	return t
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (t *TagAssociationModel) MarshalJSON() ([]byte, error) {
 	type Alias TagAssociationModel
@@ -72,6 +74,11 @@ func (t *TagAssociationModel) MarshalJSON() ([]byte, error) {
 
 func (t *TagAssociationModel) WithDependsOn(values ...string) *TagAssociationModel {
 	t.SetDependsOn(values...)
+	return t
+}
+
+func (t *TagAssociationModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *TagAssociationModel {
+	t.DynamicBlock = dynamicBlock
 	return t
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/tag_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/tag_model_gen.go
@@ -20,6 +20,8 @@ type TagModel struct {
 	FullyQualifiedName tfconfig.Variable `json:"fully_qualified_name,omitempty"`
 	MaskingPolicies    tfconfig.Variable `json:"masking_policies,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -52,9 +54,9 @@ func TagWithDefaultMeta(
 	return t
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (t *TagModel) MarshalJSON() ([]byte, error) {
 	type Alias TagModel
@@ -69,6 +71,11 @@ func (t *TagModel) MarshalJSON() ([]byte, error) {
 
 func (t *TagModel) WithDependsOn(values ...string) *TagModel {
 	t.SetDependsOn(values...)
+	return t
+}
+
+func (t *TagModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *TagModel {
+	t.DynamicBlock = dynamicBlock
 	return t
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/task_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/task_model_gen.go
@@ -86,6 +86,8 @@ type TaskModel struct {
 	WeekStart                                tfconfig.Variable `json:"week_start,omitempty"`
 	When                                     tfconfig.Variable `json:"when,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -126,9 +128,9 @@ func TaskWithDefaultMeta(
 	return t
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (t *TaskModel) MarshalJSON() ([]byte, error) {
 	type Alias TaskModel
@@ -143,6 +145,11 @@ func (t *TaskModel) MarshalJSON() ([]byte, error) {
 
 func (t *TaskModel) WithDependsOn(values ...string) *TaskModel {
 	t.SetDependsOn(values...)
+	return t
+}
+
+func (t *TaskModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *TaskModel {
+	t.DynamicBlock = dynamicBlock
 	return t
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/user_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/user_model_gen.go
@@ -94,6 +94,8 @@ type UserModel struct {
 	WeekOfYearPolicy                         tfconfig.Variable `json:"week_of_year_policy,omitempty"`
 	WeekStart                                tfconfig.Variable `json:"week_start,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -118,9 +120,9 @@ func UserWithDefaultMeta(
 	return u
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (u *UserModel) MarshalJSON() ([]byte, error) {
 	type Alias UserModel
@@ -135,6 +137,11 @@ func (u *UserModel) MarshalJSON() ([]byte, error) {
 
 func (u *UserModel) WithDependsOn(values ...string) *UserModel {
 	u.SetDependsOn(values...)
+	return u
+}
+
+func (u *UserModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *UserModel {
+	u.DynamicBlock = dynamicBlock
 	return u
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/view_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/view_model_gen.go
@@ -29,6 +29,8 @@ type ViewModel struct {
 	RowAccessPolicy    tfconfig.Variable `json:"row_access_policy,omitempty"`
 	Statement          tfconfig.Variable `json:"statement,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -65,9 +67,9 @@ func ViewWithDefaultMeta(
 	return v
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (v *ViewModel) MarshalJSON() ([]byte, error) {
 	type Alias ViewModel
@@ -82,6 +84,11 @@ func (v *ViewModel) MarshalJSON() ([]byte, error) {
 
 func (v *ViewModel) WithDependsOn(values ...string) *ViewModel {
 	v.SetDependsOn(values...)
+	return v
+}
+
+func (v *ViewModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *ViewModel {
+	v.DynamicBlock = dynamicBlock
 	return v
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/warehouse_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/model/warehouse_model_gen.go
@@ -30,6 +30,8 @@ type WarehouseModel struct {
 	WarehouseSize                   tfconfig.Variable `json:"warehouse_size,omitempty"`
 	WarehouseType                   tfconfig.Variable `json:"warehouse_type,omitempty"`
 
+	DynamicBlock *config.DynamicBlock `json:"dynamic,omitempty"`
+
 	*config.ResourceModelMeta
 }
 
@@ -54,9 +56,9 @@ func WarehouseWithDefaultMeta(
 	return w
 }
 
-///////////////////////////////////////////////////////
-// set proper json marshalling and handle depends on //
-///////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////
+// set proper json marshalling, handle depends on and dynamic blocks //
+///////////////////////////////////////////////////////////////////////
 
 func (w *WarehouseModel) MarshalJSON() ([]byte, error) {
 	type Alias WarehouseModel
@@ -71,6 +73,11 @@ func (w *WarehouseModel) MarshalJSON() ([]byte, error) {
 
 func (w *WarehouseModel) WithDependsOn(values ...string) *WarehouseModel {
 	w.SetDependsOn(values...)
+	return w
+}
+
+func (w *WarehouseModel) WithDynamicBlock(dynamicBlock *config.DynamicBlock) *WarehouseModel {
+	w.DynamicBlock = dynamicBlock
 	return w
 }
 

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/internal/tracking"


### PR DESCRIPTION
Generate dynamic blocks for all resource model builders:
- add to templates
- regenerate
- remove manually added from .ext