### PR TITLE
chore: Ensure no changes to generated model builders in pre push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ mod: ## add missing and remove unused modules
 mod-check: mod ## check if there are any missing/unused modules
 	git diff --exit-code -- go.mod go.sum
 
-pre-push: mod fmt generate-docs-additional-files docs lint test-architecture ## Run a few checks before pushing a change (docs, fmt, mod, etc.)
+pre-push: generate-all-config-model-builders-check mod fmt generate-docs-additional-files docs lint test-architecture ## Run a few checks before pushing a change (docs, fmt, mod, etc.)
 
 pre-push-check: pre-push mod-check generate-docs-additional-files-check docs-check ## Run checks before pushing a change (docs, fmt, mod, etc.)
 
@@ -187,6 +187,15 @@ generate-datasource-model-builders: ## Generate datasource model builders
 
 clean-datasource-model-builders: ## Clean datasource model builders
 	rm -f ./pkg/acceptance/bettertestspoc/config/datasourcemodel/*_gen.go
+
+clean-all-config-model-builders: clean-resource-model-builders clean-datasource-model-builders clean-provider-model-builders ## clean all generated config model builders
+
+generate-all-config-model-builders: generate-resource-model-builders generate-datasource-model-builders generate-provider-model-builders ## generate all config model builders
+
+generate-all-config-model-builders-check: clean-all-config-model-builders generate-all-config-model-builders ## check that generated config model builders are up-to-date
+	git diff --exit-code -- pkg/acceptance/bettertestspoc/config/model
+	git diff --exit-code -- pkg/acceptance/bettertestspoc/config/datasourcemodel
+	git diff --exit-code -- pkg/acceptance/bettertestspoc/config/providelmodel
 
 clean-all-assertions-and-config-models: clean-snowflake-object-assertions clean-snowflake-object-parameters-assertions clean-resource-assertions clean-resource-parameters-assertions clean-resource-show-output-assertions clean-resource-model-builders clean-provider-model-builders clean-datasource-model-builders ## clean all generated assertions and config models
 

--- a/pkg/acceptance/bettertestspoc/config/datasourcemodel/database_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/datasourcemodel/database_model_gen.go
@@ -12,11 +12,11 @@ import (
 )
 
 type DatabaseModel struct {
+	Name          tfconfig.Variable `json:"name,omitempty"`
 	Comment       tfconfig.Variable `json:"comment,omitempty"`
 	CreatedOn     tfconfig.Variable `json:"created_on,omitempty"`
 	IsCurrent     tfconfig.Variable `json:"is_current,omitempty"`
 	IsDefault     tfconfig.Variable `json:"is_default,omitempty"`
-	Name          tfconfig.Variable `json:"name,omitempty"`
 	Options       tfconfig.Variable `json:"options,omitempty"`
 	Origin        tfconfig.Variable `json:"origin,omitempty"`
 	Owner         tfconfig.Variable `json:"owner,omitempty"`
@@ -72,6 +72,11 @@ func (d *DatabaseModel) WithDependsOn(values ...string) *DatabaseModel {
 // below all the proper values //
 /////////////////////////////////
 
+func (d *DatabaseModel) WithName(name string) *DatabaseModel {
+	d.Name = tfconfig.StringVariable(name)
+	return d
+}
+
 func (d *DatabaseModel) WithComment(comment string) *DatabaseModel {
 	d.Comment = tfconfig.StringVariable(comment)
 	return d
@@ -89,11 +94,6 @@ func (d *DatabaseModel) WithIsCurrent(isCurrent bool) *DatabaseModel {
 
 func (d *DatabaseModel) WithIsDefault(isDefault bool) *DatabaseModel {
 	d.IsDefault = tfconfig.BoolVariable(isDefault)
-	return d
-}
-
-func (d *DatabaseModel) WithName(name string) *DatabaseModel {
-	d.Name = tfconfig.StringVariable(name)
 	return d
 }
 
@@ -121,6 +121,11 @@ func (d *DatabaseModel) WithRetentionTime(retentionTime int) *DatabaseModel {
 // below it's possible to set any value //
 //////////////////////////////////////////
 
+func (d *DatabaseModel) WithNameValue(value tfconfig.Variable) *DatabaseModel {
+	d.Name = value
+	return d
+}
+
 func (d *DatabaseModel) WithCommentValue(value tfconfig.Variable) *DatabaseModel {
 	d.Comment = value
 	return d
@@ -138,11 +143,6 @@ func (d *DatabaseModel) WithIsCurrentValue(value tfconfig.Variable) *DatabaseMod
 
 func (d *DatabaseModel) WithIsDefaultValue(value tfconfig.Variable) *DatabaseModel {
 	d.IsDefault = value
-	return d
-}
-
-func (d *DatabaseModel) WithNameValue(value tfconfig.Variable) *DatabaseModel {
-	d.Name = value
 	return d
 }
 

--- a/pkg/acceptance/bettertestspoc/config/datasourcemodel/database_role_model_gen.go
+++ b/pkg/acceptance/bettertestspoc/config/datasourcemodel/database_role_model_gen.go
@@ -12,9 +12,9 @@ import (
 )
 
 type DatabaseRoleModel struct {
-	Comment  tfconfig.Variable `json:"comment,omitempty"`
 	Database tfconfig.Variable `json:"database,omitempty"`
 	Name     tfconfig.Variable `json:"name,omitempty"`
+	Comment  tfconfig.Variable `json:"comment,omitempty"`
 	Owner    tfconfig.Variable `json:"owner,omitempty"`
 
 	*config.DatasourceModelMeta
@@ -71,11 +71,6 @@ func (d *DatabaseRoleModel) WithDependsOn(values ...string) *DatabaseRoleModel {
 // below all the proper values //
 /////////////////////////////////
 
-func (d *DatabaseRoleModel) WithComment(comment string) *DatabaseRoleModel {
-	d.Comment = tfconfig.StringVariable(comment)
-	return d
-}
-
 func (d *DatabaseRoleModel) WithDatabase(database string) *DatabaseRoleModel {
 	d.Database = tfconfig.StringVariable(database)
 	return d
@@ -83,6 +78,11 @@ func (d *DatabaseRoleModel) WithDatabase(database string) *DatabaseRoleModel {
 
 func (d *DatabaseRoleModel) WithName(name string) *DatabaseRoleModel {
 	d.Name = tfconfig.StringVariable(name)
+	return d
+}
+
+func (d *DatabaseRoleModel) WithComment(comment string) *DatabaseRoleModel {
+	d.Comment = tfconfig.StringVariable(comment)
 	return d
 }
 
@@ -95,11 +95,6 @@ func (d *DatabaseRoleModel) WithOwner(owner string) *DatabaseRoleModel {
 // below it's possible to set any value //
 //////////////////////////////////////////
 
-func (d *DatabaseRoleModel) WithCommentValue(value tfconfig.Variable) *DatabaseRoleModel {
-	d.Comment = value
-	return d
-}
-
 func (d *DatabaseRoleModel) WithDatabaseValue(value tfconfig.Variable) *DatabaseRoleModel {
 	d.Database = value
 	return d
@@ -107,6 +102,11 @@ func (d *DatabaseRoleModel) WithDatabaseValue(value tfconfig.Variable) *Database
 
 func (d *DatabaseRoleModel) WithNameValue(value tfconfig.Variable) *DatabaseRoleModel {
 	d.Name = value
+	return d
+}
+
+func (d *DatabaseRoleModel) WithCommentValue(value tfconfig.Variable) *DatabaseRoleModel {
+	d.Comment = value
 	return d
 }
 

--- a/pkg/acceptance/bettertestspoc/config/providermodel/gen/templates/preamble.tmpl
+++ b/pkg/acceptance/bettertestspoc/config/providermodel/gen/templates/preamble.tmpl
@@ -5,10 +5,6 @@
 package {{ .PackageName }}
 
 import (
-    {{- range .AdditionalStandardImports }}
-    "{{- . }}"
-    {{- end }}
-
     tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
     "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcc_CompleteUsageTracking(t *testing.T) {


### PR DESCRIPTION
Ensure no changes to generated model builders in pre push:
- add entries to the Makefile only for model builders for now (assertions will be covered later)
- regenerate data sources (they were affected by the recent changes in generator)
- remove additional standard imports from the provider model template (as they are not needed and hardcoded for two other use cases)