### PR TITLE
chore: Fix tests that will fail once 02_2025 is enabled

### DIFF
--- a/pkg/resources/execute_acceptance_test.go
+++ b/pkg/resources/execute_acceptance_test.go
@@ -140,7 +140,6 @@ func TestAcc_Execute_withRead(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "query_results.#"),
 					resource.TestCheckResourceAttr(resourceName, "query_results.0.name", name),
 					resource.TestCheckResourceAttrSet(resourceName, "query_results.0.created_on"),
-					resource.TestCheckResourceAttr(resourceName, "query_results.0.budget", ""),
 					resource.TestCheckResourceAttr(resourceName, "query_results.0.comment", ""),
 				),
 			},

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAcc_CompleteUsageTracking(t *testing.T) {

--- a/pkg/resources/usage_tracking_acceptance_test.go
+++ b/pkg/resources/usage_tracking_acceptance_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAcc_CompleteUsageTracking(t *testing.T) {

--- a/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
+++ b/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
@@ -21,6 +21,14 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 
 		assert.Len(t, results, 1)
 		row := results[0]
+
+		require.NotNil(t, row["name"])
+		require.NotNil(t, row["created_on"])
+		require.NotNil(t, row["owner"])
+		require.NotNil(t, row["options"])
+		require.NotNil(t, row["comment"])
+		require.NotNil(t, row["is_default"])
+
 		assert.Equal(t, testClientHelper().Ids.DatabaseId().Name(), *row["name"])
 		assert.NotEmpty(t, *row["created_on"])
 		assert.Equal(t, "STANDARD", *row["kind"])
@@ -28,7 +36,6 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 		assert.Equal(t, "", *row["options"])
 		assert.Equal(t, "", *row["comment"])
 		assert.Equal(t, "N", *row["is_default"])
-		assert.Nil(t, *row["budget"])
 	})
 
 	t.Run("test more results", func(t *testing.T) {


### PR DESCRIPTION
## Changes
- Fix tests that failed in https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/14756294570/job/41630195278 (the tests were run with BCR enabled)