### PR TITLE
chore: Add variable model builder

### DIFF
--- a/pkg/acceptance/bettertestspoc/config/commons.go
+++ b/pkg/acceptance/bettertestspoc/config/commons.go
@@ -69,3 +69,8 @@ func SecretStringVariableModelWithConfigVariables(variableName string, value str
 
 	return variableModel, configVariables
 }
+
+type TerraformBlockModel interface {
+	BlockName() string
+	BlockType() string
+}

--- a/pkg/acceptance/bettertestspoc/config/commons.go
+++ b/pkg/acceptance/bettertestspoc/config/commons.go
@@ -60,6 +60,7 @@ func NewDynamicBlock(label string, variableName string, values []string) *Dynami
 	}
 }
 
+// TODO [this PR]: add sensitive value to model builder and replace this method
 func TempSecretStringVariableConfig(variableName string, value string) (string, config.Variables) {
 	temporaryVariableDefinition := fmt.Sprintf(`
 	variable "%s" {

--- a/pkg/acceptance/bettertestspoc/config/commons.go
+++ b/pkg/acceptance/bettertestspoc/config/commons.go
@@ -60,17 +60,12 @@ func NewDynamicBlock(label string, variableName string, values []string) *Dynami
 	}
 }
 
-// TODO [this PR]: add sensitive value to model builder and replace this method
-func TempSecretStringVariableConfig(variableName string, value string) (string, config.Variables) {
-	temporaryVariableDefinition := fmt.Sprintf(`
-	variable "%s" {
-		type = string
-		sensitive = true
-	}
-`, variableName)
+func SecretStringVariableModelWithConfigVariables(variableName string, value string) (*VariableModel, config.Variables) {
+	variableModel := StringVariable(variableName).WithSensitive(true)
+
 	configVariables := config.Variables{
 		variableName: config.StringVariable(value),
 	}
 
-	return temporaryVariableDefinition, configVariables
+	return variableModel, configVariables
 }

--- a/pkg/acceptance/bettertestspoc/config/config.go
+++ b/pkg/acceptance/bettertestspoc/config/config.go
@@ -65,6 +65,26 @@ func ProviderFromModel(t *testing.T, model ProviderModel) string {
 	return hcl
 }
 
+// VariableFromModel should be used in terraform acceptance tests for Config attribute to get string config from VariableModel.
+// Current implementation is an improved implementation using two steps:
+// - .tf.json generation
+// - conversion to HCL using hcl v1 lib
+// It is still not ideal. HCL v2 should be considered.
+// TODO [this PR]: extract interface for tf common blocks when adding locals
+func VariableFromModel(t *testing.T, model VariableModel) string {
+	t.Helper()
+
+	variableJson, err := DefaultJsonConfigProvider.TfCommonJsonFromModel(model)
+	require.NoError(t, err)
+
+	hcl, err := DefaultHclConfigProvider.HclFromJson(variableJson)
+	require.NoError(t, err)
+	hcl, err = revertEqualSignForMapTypeAttributes(hcl)
+	require.NoError(t, err)
+
+	return hcl
+}
+
 // FromModels should be used in terraform acceptance tests for Config attribute to get string config from all models.
 // FromModels allows to combine multiple model types.
 // TODO [SNOW-1501905]: introduce some common interface for all three existing models (ResourceModel, DatasourceModel, and ProviderModel)
@@ -80,6 +100,8 @@ func FromModels(t *testing.T, models ...any) string {
 			sb.WriteString(DatasourceFromModel(t, m))
 		case ProviderModel:
 			sb.WriteString(ProviderFromModel(t, m))
+		case VariableModel:
+			sb.WriteString(VariableFromModel(t, m))
 		default:
 			t.Fatalf("unknown model: %T", model)
 		}

--- a/pkg/acceptance/bettertestspoc/config/config.go
+++ b/pkg/acceptance/bettertestspoc/config/config.go
@@ -70,17 +70,15 @@ func ProviderFromModel(t *testing.T, model ProviderModel) string {
 // - .tf.json generation
 // - conversion to HCL using hcl v1 lib
 // It is still not ideal. HCL v2 should be considered.
-// TODO [this PR]: extract interface for tf common blocks when adding locals
-func VariableFromModel(t *testing.T, model VariableModel) string {
+func VariableFromModel(t *testing.T, model TerraformBlockModel) string {
 	t.Helper()
 
-	variableJson, err := DefaultJsonConfigProvider.TfCommonJsonFromModel(model)
+	variableJson, err := DefaultJsonConfigProvider.TerraformBlockJsonFromModel(model)
 	require.NoError(t, err)
 
 	hcl, err := DefaultHclConfigProvider.HclFromJson(variableJson)
 	require.NoError(t, err)
-	hcl, err = revertEqualSignForMapTypeAttributes(hcl)
-	require.NoError(t, err)
+	t.Logf("Generated config:\n%s", hcl)
 
 	return hcl
 }
@@ -100,7 +98,7 @@ func FromModels(t *testing.T, models ...any) string {
 			sb.WriteString(DatasourceFromModel(t, m))
 		case ProviderModel:
 			sb.WriteString(ProviderFromModel(t, m))
-		case VariableModel:
+		case TerraformBlockModel:
 			sb.WriteString(VariableFromModel(t, m))
 		default:
 			t.Fatalf("unknown model: %T", model)

--- a/pkg/acceptance/bettertestspoc/config/config_test.go
+++ b/pkg/acceptance/bettertestspoc/config/config_test.go
@@ -222,6 +222,48 @@ provider "snowflake" {
 	})
 }
 
+func Test_VariableFromModelPoc(t *testing.T) {
+	t.Run("test string variable", func(t *testing.T) {
+		variableModel := config.StringVariable("some_variable")
+		expectedOutput := strings.TrimPrefix(`
+variable "some_variable" {
+  type = string
+}
+`, "\n")
+		result := config.VariableFromModel(t, *variableModel)
+
+		require.Equal(t, expectedOutput, result)
+	})
+
+	t.Run("test string variable with default", func(t *testing.T) {
+		variableModel := config.StringVariable("some_variable").
+			WithStringDefault("some value")
+		expectedOutput := strings.TrimPrefix(`
+variable "some_variable" {
+  type = string
+  default = "some value"
+}
+`, "\n")
+		result := config.VariableFromModel(t, *variableModel)
+
+		require.Equal(t, expectedOutput, result)
+	})
+
+	t.Run("test number variable with default", func(t *testing.T) {
+		variableModel := config.NumberVariable("some_variable").
+			WithUnquotedDefault("1")
+		expectedOutput := strings.TrimPrefix(`
+variable "some_variable" {
+  type = number
+  default = 1
+}
+`, "\n")
+		result := config.VariableFromModel(t, *variableModel)
+
+		require.Equal(t, expectedOutput, result)
+	})
+}
+
 func Test_ConfigFromModelsPoc(t *testing.T) {
 	t.Run("test basic", func(t *testing.T) {
 		providerModel := providermodel.SnowflakeProvider()

--- a/pkg/acceptance/bettertestspoc/config/config_test.go
+++ b/pkg/acceptance/bettertestspoc/config/config_test.go
@@ -231,7 +231,7 @@ variable "some_variable" {
   type = string
 }
 `, "\n")
-		result := config.VariableFromModel(t, *variableModel)
+		result := config.VariableFromModel(t, variableModel)
 
 		require.Equal(t, expectedOutput, result)
 	})
@@ -245,7 +245,7 @@ variable "some_variable" {
   default = "some value"
 }
 `, "\n")
-		result := config.VariableFromModel(t, *variableModel)
+		result := config.VariableFromModel(t, variableModel)
 
 		require.Equal(t, expectedOutput, result)
 	})
@@ -259,7 +259,7 @@ variable "some_variable" {
   default = 1
 }
 `, "\n")
-		result := config.VariableFromModel(t, *variableModel)
+		result := config.VariableFromModel(t, variableModel)
 
 		require.Equal(t, expectedOutput, result)
 	})

--- a/pkg/acceptance/bettertestspoc/config/config_test.go
+++ b/pkg/acceptance/bettertestspoc/config/config_test.go
@@ -222,6 +222,7 @@ provider "snowflake" {
 	})
 }
 
+// TODO [this PR]: test complex variable like list(object) from https://developer.hashicorp.com/terraform/language/values/variables#declaring-an-input-variable
 func Test_VariableFromModelPoc(t *testing.T) {
 	t.Run("test string variable", func(t *testing.T) {
 		variableModel := config.StringVariable("some_variable")

--- a/pkg/acceptance/bettertestspoc/config/hcl_config_provider.go
+++ b/pkg/acceptance/bettertestspoc/config/hcl_config_provider.go
@@ -68,7 +68,7 @@ func convertJsonToHclStringV1(jsonBytes []byte) (string, error) {
 // Conversion to HCL using hcl v1 does not unquote block types (i.e. `"resource"` instead of expected `resource`).
 // Check experiments subpackage for details.
 func unquoteBlockType(s string) (string, error) {
-	blockTypeRegex := regexp.MustCompile(`"(resource|data|provider|dynamic)"(( "\w+"){1,2} {)`)
+	blockTypeRegex := regexp.MustCompile(`"(resource|data|provider|dynamic|variable)"(( "\w+"){1,2} {)`)
 	return blockTypeRegex.ReplaceAllString(s, `$1$2`), nil
 }
 

--- a/pkg/acceptance/bettertestspoc/config/json_config_provider.go
+++ b/pkg/acceptance/bettertestspoc/config/json_config_provider.go
@@ -12,6 +12,7 @@ type JsonConfigProvider interface {
 	ResourceJsonFromModel(model ResourceModel) ([]byte, error)
 	DatasourceJsonFromModel(model DatasourceModel) ([]byte, error)
 	ProviderJsonFromModel(model ProviderModel) ([]byte, error)
+	TfCommonJsonFromModel(model VariableModel) ([]byte, error)
 }
 
 type basicJsonConfigProvider struct{}
@@ -64,4 +65,14 @@ func (p *basicJsonConfigProvider) ProviderJsonFromModel(model ProviderModel) ([]
 
 type providerJson struct {
 	Provider map[string]ProviderModel `json:"provider"`
+}
+
+func (p *basicJsonConfigProvider) TfCommonJsonFromModel(model VariableModel) ([]byte, error) {
+	modelJson := map[string]map[string]VariableModel{
+		model.CommonTfType(): {
+			model.CommonTfName(): model,
+		},
+	}
+
+	return json.MarshalIndent(modelJson, "", "    ")
 }

--- a/pkg/acceptance/bettertestspoc/config/json_config_provider.go
+++ b/pkg/acceptance/bettertestspoc/config/json_config_provider.go
@@ -12,7 +12,7 @@ type JsonConfigProvider interface {
 	ResourceJsonFromModel(model ResourceModel) ([]byte, error)
 	DatasourceJsonFromModel(model DatasourceModel) ([]byte, error)
 	ProviderJsonFromModel(model ProviderModel) ([]byte, error)
-	TfCommonJsonFromModel(model VariableModel) ([]byte, error)
+	TerraformBlockJsonFromModel(model TerraformBlockModel) ([]byte, error)
 }
 
 type basicJsonConfigProvider struct{}
@@ -67,10 +67,10 @@ type providerJson struct {
 	Provider map[string]ProviderModel `json:"provider"`
 }
 
-func (p *basicJsonConfigProvider) TfCommonJsonFromModel(model VariableModel) ([]byte, error) {
-	modelJson := map[string]map[string]VariableModel{
-		model.CommonTfType(): {
-			model.CommonTfName(): model,
+func (p *basicJsonConfigProvider) TerraformBlockJsonFromModel(model TerraformBlockModel) ([]byte, error) {
+	modelJson := map[string]map[string]TerraformBlockModel{
+		model.BlockType(): {
+			model.BlockName(): model,
 		},
 	}
 

--- a/pkg/acceptance/bettertestspoc/config/json_config_provider_test.go
+++ b/pkg/acceptance/bettertestspoc/config/json_config_provider_test.go
@@ -154,7 +154,7 @@ func Test_JsonConfigProvider(t *testing.T) {
     }
 }`, config.SnowflakeProviderConfigUnquoteMarker)
 
-		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		result, err := config.DefaultJsonConfigProvider.TerraformBlockJsonFromModel(variableModel)
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, string(result))
 	})
@@ -171,7 +171,7 @@ func Test_JsonConfigProvider(t *testing.T) {
     }
 }`, config.SnowflakeProviderConfigUnquoteMarker)
 
-		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		result, err := config.DefaultJsonConfigProvider.TerraformBlockJsonFromModel(variableModel)
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, string(result))
 	})
@@ -188,7 +188,7 @@ func Test_JsonConfigProvider(t *testing.T) {
     }
 }`, config.SnowflakeProviderConfigUnquoteMarker)
 
-		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		result, err := config.DefaultJsonConfigProvider.TerraformBlockJsonFromModel(variableModel)
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, string(result))
 	})

--- a/pkg/acceptance/bettertestspoc/config/json_config_provider_test.go
+++ b/pkg/acceptance/bettertestspoc/config/json_config_provider_test.go
@@ -143,4 +143,53 @@ func Test_JsonConfigProvider(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, string(result))
 	})
+
+	t.Run("test string variable json config", func(t *testing.T) {
+		variableModel := config.StringVariable("some_name")
+		expectedResult := fmt.Sprintf(`{
+    "variable": {
+        "some_name": {
+            "type": "%[1]sstring%[1]s"
+        }
+    }
+}`, config.SnowflakeProviderConfigUnquoteMarker)
+
+		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		require.NoError(t, err)
+		assert.Equal(t, expectedResult, string(result))
+	})
+
+	t.Run("test string variable with default json config", func(t *testing.T) {
+		variableModel := config.StringVariable("some_name").
+			WithStringDefault("some value")
+		expectedResult := fmt.Sprintf(`{
+    "variable": {
+        "some_name": {
+            "type": "%[1]sstring%[1]s",
+            "default": "some value"
+        }
+    }
+}`, config.SnowflakeProviderConfigUnquoteMarker)
+
+		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		require.NoError(t, err)
+		assert.Equal(t, expectedResult, string(result))
+	})
+
+	t.Run("test number variable with default json config", func(t *testing.T) {
+		variableModel := config.NumberVariable("some_name").
+			WithUnquotedDefault("1")
+		expectedResult := fmt.Sprintf(`{
+    "variable": {
+        "some_name": {
+            "type": "%[1]snumber%[1]s",
+            "default": "%[1]s1%[1]s"
+        }
+    }
+}`, config.SnowflakeProviderConfigUnquoteMarker)
+
+		result, err := config.DefaultJsonConfigProvider.TfCommonJsonFromModel(*variableModel)
+		require.NoError(t, err)
+		assert.Equal(t, expectedResult, string(result))
+	})
 }

--- a/pkg/acceptance/bettertestspoc/config/model/database_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/database_model_ext.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DatabaseWithParametersSet should be used to create database which sets the parameters that can be altered on the account level in other tests; this way, the test is not affected by the changes.
-// TODO [this PR]: consider using helper instead
+// TODO [SNOW-2100060]: consider using helper instead
 func DatabaseWithParametersSet(
 	resourceName string,
 	name string,

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -11,11 +11,11 @@ type VariableModel struct {
 	name string
 }
 
-func (v *VariableModel) CommonTfName() string {
+func (v *VariableModel) BlockName() string {
 	return v.name
 }
 
-func (v *VariableModel) CommonTfType() string {
+func (v *VariableModel) BlockType() string {
 	return "variable"
 }
 

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -2,7 +2,11 @@ package config
 
 import tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
-// TODO [this PR]: use types instead of tfconfig.Variable?
+// VariableModel allows to use predefined variable block.
+// Check: https://developer.hashicorp.com/terraform/language/values/variables#declaring-an-input-variable.
+// TODO [SNOW-1501905]: Consider using types instead of tfconfig.Variable
+//   - The reason to use tfconfig.Variable in the earlier models was to be able to put any value to also test invalid configs.
+//   - Maybe there is no sense to do that for all the fields in the Terraform predefined blocks like locals, variables, etc.
 type VariableModel struct {
 	Type      tfconfig.Variable `json:"type,omitempty"`
 	Default   tfconfig.Variable `json:"default,omitempty"`

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -58,6 +58,11 @@ func (v *VariableModel) WithStringDefault(default_ string) *VariableModel {
 	return v
 }
 
+func (v *VariableModel) WithDefault(variable tfconfig.Variable) *VariableModel {
+	v.Default = variable
+	return v
+}
+
 func (v *VariableModel) WithUnquotedDefault(default_ string) *VariableModel {
 	v.Default = UnquotedWrapperVariable(default_)
 	return v

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -40,7 +40,6 @@ func NumberVariable(
 	return Variable(variableName, "number")
 }
 
-// TODO [this PR]: use in practice
 func SetMapStringVariable(
 	variableName string,
 ) *VariableModel {

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -2,6 +2,7 @@ package config
 
 import tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
+// TODO [this PR]: use types instead of tfconfig.Variable?
 type VariableModel struct {
 	Type    tfconfig.Variable `json:"type,omitempty"`
 	Default tfconfig.Variable `json:"default,omitempty"`

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -4,8 +4,9 @@ import tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
 // TODO [this PR]: use types instead of tfconfig.Variable?
 type VariableModel struct {
-	Type    tfconfig.Variable `json:"type,omitempty"`
-	Default tfconfig.Variable `json:"default,omitempty"`
+	Type      tfconfig.Variable `json:"type,omitempty"`
+	Default   tfconfig.Variable `json:"default,omitempty"`
+	Sensitive tfconfig.Variable `json:"sensitive,omitempty"`
 
 	name string
 }
@@ -59,5 +60,10 @@ func (v *VariableModel) WithStringDefault(default_ string) *VariableModel {
 
 func (v *VariableModel) WithUnquotedDefault(default_ string) *VariableModel {
 	v.Default = UnquotedWrapperVariable(default_)
+	return v
+}
+
+func (v *VariableModel) WithSensitive(sensitive bool) *VariableModel {
+	v.Sensitive = tfconfig.BoolVariable(sensitive)
 	return v
 }

--- a/pkg/acceptance/bettertestspoc/config/variable_model.go
+++ b/pkg/acceptance/bettertestspoc/config/variable_model.go
@@ -1,1 +1,63 @@
 package config
+
+import tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
+
+type VariableModel struct {
+	Type    tfconfig.Variable `json:"type,omitempty"`
+	Default tfconfig.Variable `json:"default,omitempty"`
+
+	name string
+}
+
+func (v *VariableModel) CommonTfName() string {
+	return v.name
+}
+
+func (v *VariableModel) CommonTfType() string {
+	return "variable"
+}
+
+func Variable(
+	variableName string,
+	type_ string,
+) *VariableModel {
+	v := &VariableModel{
+		name: variableName,
+	}
+	v.WithType(type_)
+	return v
+}
+
+func StringVariable(
+	variableName string,
+) *VariableModel {
+	return Variable(variableName, "string")
+}
+
+func NumberVariable(
+	variableName string,
+) *VariableModel {
+	return Variable(variableName, "number")
+}
+
+// TODO [this PR]: use in practice
+func SetMapStringVariable(
+	variableName string,
+) *VariableModel {
+	return Variable(variableName, "set(map(string))")
+}
+
+func (v *VariableModel) WithType(type_ string) *VariableModel {
+	v.Type = UnquotedWrapperVariable(type_)
+	return v
+}
+
+func (v *VariableModel) WithStringDefault(default_ string) *VariableModel {
+	v.Default = tfconfig.StringVariable(default_)
+	return v
+}
+
+func (v *VariableModel) WithUnquotedDefault(default_ string) *VariableModel {
+	v.Default = UnquotedWrapperVariable(default_)
+	return v
+}

--- a/pkg/datasources/masking_policies_acceptance_test.go
+++ b/pkg/datasources/masking_policies_acceptance_test.go
@@ -121,6 +121,7 @@ func TestAcc_MaskingPolicies_Filtering(t *testing.T) {
 	maskingPoliciesModelLikePrefix := datasourcemodel.MaskingPolicies("test").
 		WithLike(prefix+"%").
 		WithDependsOn(maskingPolicyModel1.ResourceReference(), maskingPolicyModel2.ResourceReference(), maskingPolicyModel3.ResourceReference())
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -131,11 +132,6 @@ func TestAcc_MaskingPolicies_Filtering(t *testing.T) {
 		),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -145,14 +141,14 @@ func TestAcc_MaskingPolicies_Filtering(t *testing.T) {
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, maskingPolicyModel1, maskingPolicyModel2, maskingPolicyModel3, maskingPoliciesModelLikeFirstOne) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, maskingPolicyModel1, maskingPolicyModel2, maskingPolicyModel3, maskingPoliciesModelLikeFirstOne),
 				ConfigVariables: commonVariables,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.snowflake_masking_policies.test", "masking_policies.#", "1"),
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, maskingPolicyModel1, maskingPolicyModel2, maskingPolicyModel3, maskingPoliciesModelLikePrefix) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, maskingPolicyModel1, maskingPolicyModel2, maskingPolicyModel3, maskingPoliciesModelLikePrefix),
 				ConfigVariables: commonVariables,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.snowflake_masking_policies.test", "masking_policies.#", "2"),

--- a/pkg/datasources/security_integrations_acceptance_test.go
+++ b/pkg/datasources/security_integrations_acceptance_test.go
@@ -36,7 +36,7 @@ func TestAcc_SecurityIntegrations_MultipleTypes(t *testing.T) {
 	role := snowflakeroles.GenericScimProvisioner
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	saml2Model := model.Saml2SecurityIntegrationVar("test", idOne.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 	scimModel := model.ScimSecurityIntegration("test", idTwo.Name(), true, role.Name(), string(sdk.ScimSecurityIntegrationScimClientGeneric))
@@ -52,7 +52,7 @@ func TestAcc_SecurityIntegrations_MultipleTypes(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, scimModel, saml2Model, securityIntegrationsModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, scimModel, saml2Model, securityIntegrationsModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(securityIntegrationsModel.DatasourceReference(), "security_integrations.#", "2"),
@@ -521,7 +521,7 @@ func TestAcc_SecurityIntegrations_Saml2(t *testing.T) {
 	comment := random.Comment()
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	// TODO(SNOW-1479617): set saml2_snowflake_x509_cert
 	resourceModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
@@ -554,7 +554,7 @@ func TestAcc_SecurityIntegrations_Saml2(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.Saml2SecurityIntegration),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, resourceModel, securityIntegrationsModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, resourceModel, securityIntegrationsModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(securityIntegrationsModel.DatasourceReference(), "security_integrations.#", "1"),

--- a/pkg/datasources/security_integrations_acceptance_test.go
+++ b/pkg/datasources/security_integrations_acceptance_test.go
@@ -590,7 +590,7 @@ func TestAcc_SecurityIntegrations_Saml2(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, resourceModel, securityIntegrationsModelWithoutDescribe) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, resourceModel, securityIntegrationsModelWithoutDescribe, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(securityIntegrationsModelWithoutDescribe.DatasourceReference(), "security_integrations.#", "1"),

--- a/pkg/resources/row_access_policy_acceptance_test.go
+++ b/pkg/resources/row_access_policy_acceptance_test.go
@@ -345,6 +345,7 @@ func TestAcc_RowAccessPolicy_InvalidDataType(t *testing.T) {
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -355,12 +356,6 @@ func TestAcc_RowAccessPolicy_InvalidDataType(t *testing.T) {
 		),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -369,7 +364,7 @@ func TestAcc_RowAccessPolicy_InvalidDataType(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				PlanOnly:        true,
 				ExpectError:     regexp.MustCompile(`invalid data type: invalid-type`),
@@ -578,6 +573,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0(t *testing.T) {
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -588,12 +584,6 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0(t *testing.T) {
 		),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
@@ -603,7 +593,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0(t *testing.T) {
 			{
 				PreConfig:         func() { acc.SetLegacyConfigPathEnv(t) },
 				ExternalProviders: acc.ExternalProviderWithExactVersion("1.2.1"),
-				Config:            accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:            accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables:   commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -615,7 +605,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0(t *testing.T) {
 			{
 				PreConfig:                func() { acc.UnsetConfigPathEnv(t) },
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
-				Config:                   accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:                   accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables:          commonVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -644,6 +634,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0_nonDefaultInConfig(t *testing.T) {
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -654,12 +645,6 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0_nonDefaultInConfig(t *testing.T) {
 		),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.RequireAbove(tfversion.Version1_5_0),
@@ -669,7 +654,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0_nonDefaultInConfig(t *testing.T) {
 			{
 				PreConfig:         func() { acc.SetLegacyConfigPathEnv(t) },
 				ExternalProviders: acc.ExternalProviderWithExactVersion("1.2.1"),
-				Config:            accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:            accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables:   commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -683,7 +668,7 @@ func TestAcc_RowAccessPolicy_migrateToV2_0_0_nonDefaultInConfig(t *testing.T) {
 			{
 				PreConfig:                func() { acc.UnsetConfigPathEnv(t) },
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
-				Config:                   accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:                   accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables:          commonVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -712,6 +697,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentDefaultToSpecific(t *testing.T) {
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -731,12 +717,6 @@ func TestAcc_RowAccessPolicy_dataType_argumentDefaultToSpecific(t *testing.T) {
 		),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -745,7 +725,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentDefaultToSpecific(t *testing.T) {
 		PreCheck: func() { acc.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -763,7 +743,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentDefaultToSpecific(t *testing.T) {
 						plancheck.ExpectResourceAction(policyModel.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: updatedDataType,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -787,6 +767,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChange(t *testing.T) {
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -801,12 +782,6 @@ func TestAcc_RowAccessPolicy_dataType_externalChange(t *testing.T) {
 		*sdk.NewCreateRowAccessPolicyArgsRequest("A", testdatatypes.DataTypeNumber),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -816,7 +791,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChange(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.RowAccessPolicy),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -839,7 +814,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChange(t *testing.T) {
 						plancheck.ExpectResourceAction(policyModel.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -863,6 +838,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentExternalChangeSuppressed(t *testin
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -877,12 +853,6 @@ func TestAcc_RowAccessPolicy_dataType_argumentExternalChangeSuppressed(t *testin
 		*sdk.NewCreateRowAccessPolicyArgsRequest("A", testdatatypes.DataTypeVarchar_100),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -892,7 +862,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentExternalChangeSuppressed(t *testin
 		CheckDestroy: acc.CheckDestroy(t, resources.RowAccessPolicy),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -915,7 +885,7 @@ func TestAcc_RowAccessPolicy_dataType_argumentExternalChangeSuppressed(t *testin
 						plancheck.ExpectResourceAction(policyModel.ResourceReference(), plancheck.ResourceActionNoop),
 					},
 				},
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -939,6 +909,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeMoreArguments(t *testing.T) 
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -954,12 +925,6 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeMoreArguments(t *testing.T) 
 		*sdk.NewCreateRowAccessPolicyArgsRequest("B", testdatatypes.DataTypeVarchar),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -969,7 +934,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeMoreArguments(t *testing.T) 
 		CheckDestroy: acc.CheckDestroy(t, resources.RowAccessPolicy),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -992,7 +957,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeMoreArguments(t *testing.T) 
 						plancheck.ExpectResourceAction(policyModel.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -1016,6 +981,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeFewerArguments(t *testing.T)
 
 	body := "case when current_role() in ('ANALYST') then true else false end"
 	policyModel := model.RowAccessPolicyDynamicArguments("test", id, body)
+	variableModel := accconfig.SetMapStringVariable("arguments")
 
 	commonVariables := config.Variables{
 		"arguments": config.SetVariable(
@@ -1034,12 +1000,6 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeFewerArguments(t *testing.T)
 		*sdk.NewCreateRowAccessPolicyArgsRequest("A", testdatatypes.DataTypeVarchar),
 	}
 
-	temporaryVariableDefinition := `
-	variable "arguments" {
-		type = set(map(string))
-	}
-`
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
 		PreCheck:                 func() { acc.TestAccPreCheck(t) },
@@ -1049,7 +1009,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeFewerArguments(t *testing.T)
 		CheckDestroy: acc.CheckDestroy(t, resources.RowAccessPolicy),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).
@@ -1076,7 +1036,7 @@ func TestAcc_RowAccessPolicy_dataType_externalChangeFewerArguments(t *testing.T)
 						plancheck.ExpectResourceAction(policyModel.ResourceReference(), plancheck.ResourceActionDestroyBeforeCreate),
 					},
 				},
-				Config:          accconfig.FromModels(t, policyModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, variableModel, policyModel),
 				ConfigVariables: commonVariables,
 				Check: assertThat(t, resourceassert.RowAccessPolicyResource(t, policyModel.ResourceReference()).
 					HasFullyQualifiedNameString(id.FullyQualifiedName()).

--- a/pkg/resources/saml2_integration_acceptance_test.go
+++ b/pkg/resources/saml2_integration_acceptance_test.go
@@ -39,8 +39,8 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 	comment := random.Comment()
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
-	_, configVariables2 := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert2)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
+	_, configVariables2 := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert2)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 	// TODO(SNOW-1479617): set saml2_snowflake_x509_cert
@@ -75,7 +75,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create with empty optionals
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(basicModel.ResourceReference(), "name", id.Name()),
@@ -128,7 +128,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 			},
 			// import - without optionals
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ResourceName:    basicModel.ResourceReference(),
 				ImportState:     true,
@@ -154,7 +154,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 			},
 			// set optionals
 			{
-				Config:          accconfig.FromModels(t, completeModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, completeModel, temporaryVariableModel),
 				ConfigVariables: configVariables2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(completeModel.ResourceReference(), "name", id.Name()),
@@ -209,7 +209,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 			},
 			// import - complete
 			{
-				Config:          accconfig.FromModels(t, completeModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, completeModel, temporaryVariableModel),
 				ConfigVariables: configVariables2,
 				ResourceName:    completeModel.ResourceReference(),
 				ImportState:     true,
@@ -237,7 +237,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 			},
 			// change values externally
 			{
-				Config:          accconfig.FromModels(t, completeModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, completeModel, temporaryVariableModel),
 				ConfigVariables: configVariables2,
 				PreConfig: func() {
 					acc.TestClient().SecurityIntegration.UpdateSaml2(t, sdk.NewAlterSaml2SecurityIntegrationRequest(id).
@@ -313,7 +313,7 @@ func TestAcc_Saml2Integration_basic(t *testing.T) {
 			},
 			// unset
 			{
-				Config:          accconfig.FromModels(t, recreatesModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, recreatesModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(recreatesModel.ResourceReference(), "name", id.Name()),
@@ -380,7 +380,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 	saml2ConfigForceAuthnTrueModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
@@ -405,7 +405,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 						planchecks.ExpectComputed(saml2ConfigForceAuthnTrueModel.ResourceReference(), "describe_output", true),
 					},
 				},
-				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(saml2ConfigForceAuthnTrueModel.ResourceReference(), "saml2_force_authn", "true"),
@@ -433,7 +433,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 						planchecks.ExpectComputed(saml2ConfigForceAuthnFalseModel.ResourceReference(), "describe_output", true),
 					},
 				},
-				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnFalseModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnFalseModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(saml2ConfigForceAuthnFalseModel.ResourceReference(), "saml2_force_authn", "false"),
@@ -443,12 +443,12 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 			},
 			// change back to non-default
 			{
-				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 			},
 			// remove non-default saml2_force_authn from config
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -472,7 +472,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnFalseModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnFalseModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(saml2ConfigForceAuthnFalseModel.ResourceReference(), "saml2_force_authn", r.BooleanDefault),
@@ -482,7 +482,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 			},
 			// change back to non-default
 			{
-				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, saml2ConfigForceAuthnTrueModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 			},
 			// remove saml2_force_authn from config but update externally to default (still expecting non-empty plan because we do not know the default)
@@ -490,7 +490,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 				PreConfig: func() {
 					acc.TestClient().SecurityIntegration.UpdateSaml2ForceAuthn(t, id, false)
 				},
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -512,7 +512,7 @@ func TestAcc_Saml2Integration_forceAuthn(t *testing.T) {
 					// we change the type to the type different from default, expecting action
 					acc.TestClient().SecurityIntegration.UpdateSaml2ForceAuthn(t, id, true)
 				},
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -556,7 +556,7 @@ func TestAcc_Saml2Integration_complete(t *testing.T) {
 	comment := random.Comment()
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	// TODO(SNOW-1479617): set saml2_snowflake_x509_cert
 	completeModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
@@ -583,7 +583,7 @@ func TestAcc_Saml2Integration_complete(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.Saml2SecurityIntegration),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, completeModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, completeModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(completeModel.ResourceReference(), "name", id.Name()),
@@ -638,7 +638,7 @@ func TestAcc_Saml2Integration_complete(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, completeModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, completeModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ResourceName:    completeModel.ResourceReference(),
 				ImportState:     true,
@@ -679,7 +679,7 @@ func TestAcc_Saml2Integration_InvalidNameIdFormat(t *testing.T) {
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
 		WithSaml2RequestedNameidFormat("invalid")
@@ -693,7 +693,7 @@ func TestAcc_Saml2Integration_InvalidNameIdFormat(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.Saml2SecurityIntegration),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				PlanOnly:        true,
 				ExpectError:     regexp.MustCompile("Error: invalid Saml2SecurityIntegrationSaml2RequestedNameidFormatOption: invalid"),
@@ -712,7 +712,7 @@ func TestAcc_Saml2Integration_InvalidProvider(t *testing.T) {
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, "invalid", validUrl, temporaryVariableName)
 
@@ -725,7 +725,7 @@ func TestAcc_Saml2Integration_InvalidProvider(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.Saml2SecurityIntegration),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				PlanOnly:        true,
 				ExpectError:     regexp.MustCompile("Error: invalid Saml2SecurityIntegrationSaml2ProviderOption: INVALID"),
@@ -746,7 +746,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 	issuerURL := acc.TestClient().Context.IssuerURL(t)
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	baseModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
 		WithSaml2SnowflakeAcsUrl(acsURL).
@@ -794,7 +794,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 		CheckDestroy: acc.CheckDestroy(t, resources.Saml2SecurityIntegration),
 		Steps: []resource.TestStep{
 			{
-				Config:          accconfig.FromModels(t, baseModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, baseModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(baseModel.ResourceReference(), "name", id.Name()),
@@ -809,7 +809,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, withoutLoginPageLabelModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withoutLoginPageLabelModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -835,7 +835,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, withoutSnowflakeIssuerUrlModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withoutSnowflakeIssuerUrlModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -861,7 +861,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, withoutAcsUrlModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withoutAcsUrlModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -887,7 +887,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, withoutAllowedEmailPatternsModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withoutAllowedEmailPatternsModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -912,7 +912,7 @@ func TestAcc_Saml2Integration_ForceNewIfEmpty(t *testing.T) {
 				),
 			},
 			{
-				Config:          accconfig.FromModels(t, withoutAllowedUserDomainsModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withoutAllowedUserDomainsModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -947,7 +947,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 	withZeroValuesModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName).
@@ -969,7 +969,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 		Steps: []resource.TestStep{
 			// create with valid "zero" values
 			{
-				Config:          accconfig.FromModels(t, withZeroValuesModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withZeroValuesModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -995,7 +995,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 			},
 			// remove all from config (to validate that unset is run correctly)
 			{
-				Config:          accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1021,7 +1021,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 			},
 			// set to "non-zero" values
 			{
-				Config:          accconfig.FromModels(t, withNonZeroValuesModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withNonZeroValuesModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(withNonZeroValuesModel.ResourceReference(), "enabled", "true"),
@@ -1038,7 +1038,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 			},
 			// add valid "zero" values again (to validate if set is run correctly)
 			{
-				Config:          accconfig.FromModels(t, withZeroValuesModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withZeroValuesModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -1064,7 +1064,7 @@ func TestAcc_Saml2Integration_DefaultValues(t *testing.T) {
 			},
 			// import zero values
 			{
-				Config:          accconfig.FromModels(t, withZeroValuesModel) + temporaryVariableDefinition,
+				Config:          accconfig.FromModels(t, withZeroValuesModel, temporaryVariableModel),
 				ConfigVariables: configVariables,
 				ImportState:     true,
 				ResourceName:    withZeroValuesModel.ResourceReference(),
@@ -1094,7 +1094,7 @@ func TestAcc_Saml2Integration_migrateFromV0941_ensureSmoothUpgradeWithNewResourc
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", id.Name(), issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 
@@ -1108,7 +1108,7 @@ func TestAcc_Saml2Integration_migrateFromV0941_ensureSmoothUpgradeWithNewResourc
 			{
 				PreConfig:         func() { acc.SetV097CompatibleConfigPathEnv(t) },
 				ExternalProviders: acc.ExternalProviderWithExactVersion("0.94.1"),
-				Config:            accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:            accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables:   configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_saml2_integration.test", "id", id.Name()),
@@ -1117,7 +1117,7 @@ func TestAcc_Saml2Integration_migrateFromV0941_ensureSmoothUpgradeWithNewResourc
 			{
 				PreConfig:                func() { acc.UnsetConfigPathEnv(t) },
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
-				Config:                   accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:                   accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables:          configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_saml2_integration.test", "id", id.Name()),
@@ -1138,7 +1138,7 @@ func TestAcc_Saml2Integration_IdentifierQuotingDiffSuppression(t *testing.T) {
 	validUrl := "https://example.com"
 
 	temporaryVariableName := "saml2_x509_cert"
-	temporaryVariableDefinition, configVariables := accconfig.TempSecretStringVariableConfig(temporaryVariableName, cert)
+	temporaryVariableModel, configVariables := accconfig.SecretStringVariableModelWithConfigVariables(temporaryVariableName, cert)
 
 	basicModel := model.Saml2SecurityIntegrationVar("test", quotedId, issuer, string(sdk.Saml2SecurityIntegrationSaml2ProviderCustom), validUrl, temporaryVariableName)
 
@@ -1153,7 +1153,7 @@ func TestAcc_Saml2Integration_IdentifierQuotingDiffSuppression(t *testing.T) {
 				PreConfig:          func() { acc.SetV097CompatibleConfigPathEnv(t) },
 				ExternalProviders:  acc.ExternalProviderWithExactVersion("0.94.1"),
 				ExpectNonEmptyPlan: true,
-				Config:             accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:             accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables:    configVariables,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("snowflake_saml2_integration.test", "name", id.Name()),
@@ -1163,7 +1163,7 @@ func TestAcc_Saml2Integration_IdentifierQuotingDiffSuppression(t *testing.T) {
 			{
 				PreConfig:                func() { acc.UnsetConfigPathEnv(t) },
 				ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
-				Config:                   accconfig.FromModels(t, basicModel) + temporaryVariableDefinition,
+				Config:                   accconfig.FromModels(t, basicModel, temporaryVariableModel),
 				ConfigVariables:          configVariables,
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{


### PR DESCRIPTION
Extract a common builder for variable model:
- Support new model type in `FromModels`
- Use in all inline places where the vars were used (not touching the setups using `ConfigFile`)
- Add TODOs for later