### PR TITLE
chore: Fix tests that run on secondary account profile

### DIFF
--- a/pkg/resources/grant_account_role_acceptance_test.go
+++ b/pkg/resources/grant_account_role_acceptance_test.go
@@ -238,6 +238,7 @@ resource "snowflake_grant_account_role" "test" {
 func TestAcc_GrantAccountRole_Issue_3629(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	accountRole, accountRoleCleanup := acc.SecondaryTestClient().Role.CreateRole(t)
 	t.Cleanup(accountRoleCleanup)

--- a/pkg/resources/grant_database_role_account_level_acceptance_test.go
+++ b/pkg/resources/grant_database_role_account_level_acceptance_test.go
@@ -27,6 +27,7 @@ import (
 func TestAcc_GrantDatabaseRole_Issue_3629(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	databaseRole, databaseRoleCleanup := acc.SecondaryTestClient().DatabaseRole.CreateDatabaseRole(t)
 	t.Cleanup(databaseRoleCleanup)

--- a/pkg/resources/grant_privileges_to_account_role_account_level_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_account_role_account_level_acceptance_test.go
@@ -22,6 +22,7 @@ import (
 func TestAcc_GrantPrivilegesToAccountRole_OnDatabase_WithPrivilegesGrantedOnDatabaseToUser(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	role, roleCleanup := acc.SecondaryTestClient().Role.CreateRole(t)
 	t.Cleanup(roleCleanup)

--- a/pkg/resources/grant_privileges_to_database_role_account_level_acceptance_test.go
+++ b/pkg/resources/grant_privileges_to_database_role_account_level_acceptance_test.go
@@ -23,6 +23,7 @@ import (
 func TestAcc_GrantPrivilegesToDatabaseRole_OnDatabase_WithPrivilegesGrantedOnDatabaseToUser(t *testing.T) {
 	_ = testenvs.GetOrSkipTest(t, testenvs.EnableAcceptance)
 	acc.TestAccPreCheck(t)
+	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	databaseRole, databaseRoleCleanup := acc.SecondaryTestClient().DatabaseRole.CreateDatabaseRole(t)
 	t.Cleanup(databaseRoleCleanup)

--- a/pkg/sdk/testint/grants_account_level_integration_test.go
+++ b/pkg/sdk/testint/grants_account_level_integration_test.go
@@ -20,7 +20,7 @@ func TestInt_ShowGrants_To_Users(t *testing.T) {
 		accountRole, accountRoleCleanup := secondaryTestClientHelper().Role.CreateRole(t)
 		t.Cleanup(accountRoleCleanup)
 
-		secondaryTestClientHelper().Grant.GrantAccountRoleToUser(t, accountRole.ID(), user.ID())
+		secondaryTestClientHelper().Role.GrantRoleToUser(t, accountRole.ID(), user.ID())
 		grants, err := secondaryTestClientHelper().Grant.ShowGrantsOfAccountRole(t, accountRole.ID())
 		require.NoError(t, err)
 


### PR DESCRIPTION
- Some of the tests were passing during the local development, but failed on CI. This was because `ConfigureClientOnce` setting was set for them. This pr unsets it for those tests to fix them on CI.