### PR TITLE
docs: Update v095 migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1779,6 +1779,19 @@ Both topics will be addressed in the following versions.
 
 `service` and `legacy_service` user types are currently not supported. They will be supported in the following versions as separate resources (namely `snowflake_service_user` and `snowflake_legacy_service_user`).
 
+If you used the existing `snowflake_user` and altered its type externally (manually or through `snowflake_unsafe_execute`), then after migrating to v0.95.0 the provider will try to recreate it as a `person` type.
+
+Because `snowflake_service_user` and `snowflake_legacy_service_user` resources are available in v0.97.0 version, you can temporarily suppress these changes to allow version-by-version migration. To do that, use [`ignore_changes`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) meta-attribute:
+
+```hcl
+resource "snowflake_user" "example_user" {
+  # ...
+  lifecycle {
+    ignore_changes = [ user_type ]
+  }
+}
+```
+
 ## v0.94.0 ➞ v0.94.1
 ### changes in snowflake_schema
 


### PR DESCRIPTION
Update `snowflake_user` resource in the v0.95.0 migration guide (how to avoid diff recognition for `user_type`). This should simplify the migration for customers.