### PR TITLE
fix: Fix parsing username in handling grants

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -34,6 +34,11 @@ This feature will be marked as a stable feature in future releases. Breaking cha
 
 The [snowflake_tag_association](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/tag_association) can now be used for managing tags in [image repositories](https://docs.snowflake.com/en/sql-reference/sql/create-image-repository).
 
+### *(bugfix)* Fixed handling users' grants
+
+In v2.1.0, we introduced a fix in handling users' grants ([migration guide](#bugfix-fixed-snowflake_grant_database_role-resource)), which addressed changes in the `2025_02` bundle. The username was parsed incorrectly if it had a prefix formed of `U`, `S`, `E`, and `R` characters. The username returned from `SHOW GRANTS` was incorrect in this case. Now, such names should be handled correctly.
+No configuration changes are necessary.
+
 ## v2.0.0 ➞ v2.1.0
 
 ### *(bugfix)* Fixed `snowflake_tag_association` resource

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -271,7 +271,7 @@ func (v *grants) Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, err
 			}
 			resultList[i].GranteeName = id
 		} else if grant.GrantedTo == ObjectTypeUser {
-			resultList[i].GranteeName = NewAccountObjectIdentifier(strings.TrimLeft(granteeNameRaw, "USER$"))
+			resultList[i].GranteeName = NewAccountObjectIdentifier(strings.TrimPrefix(granteeNameRaw, "USER$"))
 		} else {
 			resultList[i].GranteeName = NewAccountObjectIdentifier(granteeNameRaw)
 		}

--- a/pkg/sdk/testint/grants_account_level_integration_test.go
+++ b/pkg/sdk/testint/grants_account_level_integration_test.go
@@ -26,7 +26,7 @@ func TestInt_ShowGrants_To_Users(t *testing.T) {
 
 		assert.Len(t, grants, 1)
 		assert.Equal(t, sdk.ObjectTypeUser, grants[0].GrantedTo)
-		assert.Equal(t, grants[0].GranteeName.FullyQualifiedName(), user.ID().FullyQualifiedName())
+		assert.Equal(t, user.ID().FullyQualifiedName(), grants[0].GranteeName.FullyQualifiedName())
 	})
 
 	t.Run("handles granteeName for database role granted to user", func(t *testing.T) {
@@ -42,6 +42,22 @@ func TestInt_ShowGrants_To_Users(t *testing.T) {
 
 		assert.Len(t, grants, 1)
 		assert.Equal(t, sdk.ObjectTypeUser, grants[0].GrantedTo)
-		assert.Equal(t, grants[0].GranteeName.FullyQualifiedName(), user.ID().FullyQualifiedName())
+		assert.Equal(t, user.ID().FullyQualifiedName(), grants[0].GranteeName.FullyQualifiedName())
+	})
+
+	t.Run("correctly parses a username with a prefix formed of U/S/E/R characters", func(t *testing.T) {
+		user, userCleanup := secondaryTestClientHelper().User.CreateUserWithPrefix(t, "USER")
+		t.Cleanup(userCleanup)
+
+		databaseRole, databaseRoleCleanup := secondaryTestClientHelper().DatabaseRole.CreateDatabaseRole(t)
+		t.Cleanup(databaseRoleCleanup)
+
+		secondaryTestClientHelper().Grant.GrantDatabaseRoleToUser(t, databaseRole.ID(), user.ID())
+		grants, err := secondaryTestClientHelper().Grant.ShowGrantsOfDatabaseRole(t, databaseRole.ID())
+		require.NoError(t, err)
+
+		assert.Len(t, grants, 1)
+		assert.Equal(t, sdk.ObjectTypeUser, grants[0].GrantedTo)
+		assert.Equal(t, user.ID().FullyQualifiedName(), grants[0].GranteeName.FullyQualifiedName())
 	})
 }


### PR DESCRIPTION
Recently, we introduced a fix in handling users' grants, which addressed changes in the `2025_02` bundle. The username was parsed incorrectly if it had a prefix formed of `U`, `S`, `E`, and `R` characters. The username returned from `SHOW GRANTS` was incorrect in this case. Now, such names should be handled correctly.

Additionally, fix the parameter order in `assert.Equal` in a related test.