### PR TITLE
fix: Adjust function and procedure tests

### DIFF
--- a/docs/resources/function_python.md
+++ b/docs/resources/function_python.md
@@ -39,7 +39,7 @@ resource "snowflake_function_python" "minimal" {
   database        = snowflake_database.test.name
   schema          = snowflake_schema.test.name
   name            = "my_function_function"
-  runtime_version = "3.8"
+  runtime_version = "3.9"
   arguments {
     arg_data_type = "NUMBER(36, 2)"
     arg_name      = "x"

--- a/docs/resources/procedure_python.md
+++ b/docs/resources/procedure_python.md
@@ -55,7 +55,7 @@ resource "snowflake_procedure_python" "w" {
     result += x
   return result
 EOT
-  runtime_version      = "3.8"
+  runtime_version      = "3.9"
   snowpark_package     = "1.14.0"
 }
 ```

--- a/examples/resources/snowflake_function_python/resource.tf
+++ b/examples/resources/snowflake_function_python/resource.tf
@@ -3,7 +3,7 @@ resource "snowflake_function_python" "minimal" {
   database        = snowflake_database.test.name
   schema          = snowflake_schema.test.name
   name            = "my_function_function"
-  runtime_version = "3.8"
+  runtime_version = "3.9"
   arguments {
     arg_data_type = "NUMBER(36, 2)"
     arg_name      = "x"

--- a/examples/resources/snowflake_procedure_python/resource.tf
+++ b/examples/resources/snowflake_procedure_python/resource.tf
@@ -15,6 +15,6 @@ resource "snowflake_procedure_python" "w" {
     result += x
   return result
 EOT
-  runtime_version      = "3.8"
+  runtime_version      = "3.9"
   snowpark_package     = "1.14.0"
 }

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
@@ -15,7 +15,7 @@ func ProcedurePythonBasicInline(
 	handler string,
 	procedureDefinition string,
 ) *ProcedurePythonModel {
-	return ProcedurePython(resourceName, id.DatabaseName(), id.SchemaName(), id.Name(), handler, returnType.ToSql(), "3.8", "1.14.0").
+	return ProcedurePython(resourceName, id.DatabaseName(), id.SchemaName(), id.Name(), handler, returnType.ToSql(), "3.9", "1.14.0").
 		WithProcedureDefinition(procedureDefinition)
 }
 

--- a/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
+++ b/pkg/acceptance/bettertestspoc/config/model/procedure_python_model_ext.go
@@ -3,6 +3,7 @@ package model
 import (
 	tfconfig "github.com/hashicorp/terraform-plugin-testing/config"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -15,7 +16,7 @@ func ProcedurePythonBasicInline(
 	handler string,
 	procedureDefinition string,
 ) *ProcedurePythonModel {
-	return ProcedurePython(resourceName, id.DatabaseName(), id.SchemaName(), id.Name(), handler, returnType.ToSql(), "3.9", "1.14.0").
+	return ProcedurePython(resourceName, id.DatabaseName(), id.SchemaName(), id.Name(), handler, returnType.ToSql(), testvars.PythonRuntime, "1.14.0").
 		WithProcedureDefinition(procedureDefinition)
 }
 

--- a/pkg/acceptance/helpers/function_setup_helpers.go
+++ b/pkg/acceptance/helpers/function_setup_helpers.go
@@ -145,7 +145,7 @@ func (c *TestClient) CreateSamplePythonFunctionAndModuleInLocation(t *testing.T,
 	returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 	definition := c.Function.SamplePythonDefinition(t, funcName, argName)
 
-	request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.8", funcName).
+	request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
 		WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 		WithFunctionDefinitionWrapped(definition)
 

--- a/pkg/acceptance/helpers/function_setup_helpers.go
+++ b/pkg/acceptance/helpers/function_setup_helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
 	"github.com/stretchr/testify/require"
@@ -145,7 +146,7 @@ func (c *TestClient) CreateSamplePythonFunctionAndModuleInLocation(t *testing.T,
 	returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 	definition := c.Function.SamplePythonDefinition(t, funcName, argName)
 
-	request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
+	request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, funcName).
 		WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 		WithFunctionDefinitionWrapped(definition)
 

--- a/pkg/acceptance/testvars/functions_and_procedures.go
+++ b/pkg/acceptance/testvars/functions_and_procedures.go
@@ -1,0 +1,3 @@
+package testvars
+
+const PythonRuntime = "3.10"

--- a/pkg/sdk/functions_gen_test.go
+++ b/pkg/sdk/functions_gen_test.go
@@ -636,7 +636,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 		opts.ReturnNullValues = ReturnNullValuesPointer(ReturnNullValuesNotNull)
 		opts.NullInputBehavior = NullInputBehaviorPointer(NullInputBehaviorCalledOnNullInput)
 		opts.ReturnResultsBehavior = ReturnResultsBehaviorPointer(ReturnResultsBehaviorImmutable)
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Comment = String("comment")
 		opts.Imports = []FunctionImport{
 			{
@@ -669,7 +669,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 			},
 		}
 		opts.FunctionDefinition = String(wrapFunctionDefinition("import numpy as np"))
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TEMPORARY SECURE FUNCTION %s ("i" NUMBER DEFAULT 1) COPY GRANTS RETURNS VARIANT NOT NULL LANGUAGE PYTHON CALLED ON NULL INPUT IMMUTABLE RUNTIME_VERSION = '3.8' COMMENT = 'comment' IMPORTS = ('numpy', 'pandas') PACKAGES = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) AS $$import numpy as np$$`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TEMPORARY SECURE FUNCTION %s ("i" NUMBER DEFAULT 1) COPY GRANTS RETURNS VARIANT NOT NULL LANGUAGE PYTHON CALLED ON NULL INPUT IMMUTABLE RUNTIME_VERSION = '3.9' COMMENT = 'comment' IMPORTS = ('numpy', 'pandas') PACKAGES = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) AS $$import numpy as np$$`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
 	})
 
 	t.Run("all options", func(t *testing.T) {
@@ -693,7 +693,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 		opts.ReturnNullValues = ReturnNullValuesPointer(ReturnNullValuesNotNull)
 		opts.NullInputBehavior = NullInputBehaviorPointer(NullInputBehaviorCalledOnNullInput)
 		opts.ReturnResultsBehavior = ReturnResultsBehaviorPointer(ReturnResultsBehaviorImmutable)
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Comment = String("comment")
 		opts.Imports = []FunctionImport{
 			{
@@ -726,7 +726,7 @@ func TestFunctions_CreateForPython(t *testing.T) {
 			},
 		}
 		opts.FunctionDefinition = String(wrapFunctionDefinition("import numpy as np"))
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TEMPORARY SECURE FUNCTION %s ("i" NUMBER(36, 2) DEFAULT 1) COPY GRANTS RETURNS VARIANT NOT NULL LANGUAGE PYTHON CALLED ON NULL INPUT IMMUTABLE RUNTIME_VERSION = '3.8' COMMENT = 'comment' IMPORTS = ('numpy', 'pandas') PACKAGES = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) AS $$import numpy as np$$`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE TEMPORARY SECURE FUNCTION %s ("i" NUMBER(36, 2) DEFAULT 1) COPY GRANTS RETURNS VARIANT NOT NULL LANGUAGE PYTHON CALLED ON NULL INPUT IMMUTABLE RUNTIME_VERSION = '3.9' COMMENT = 'comment' IMPORTS = ('numpy', 'pandas') PACKAGES = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) AS $$import numpy as np$$`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
 	})
 }
 

--- a/pkg/sdk/procedures_gen_test.go
+++ b/pkg/sdk/procedures_gen_test.go
@@ -389,7 +389,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 	defaultOpts := func() *CreateForPythonProcedureOptions {
 		return &CreateForPythonProcedureOptions{
 			name:           id,
-			RuntimeVersion: "3.8",
+			RuntimeVersion: "3.9",
 			Packages: []ProcedurePackage{
 				{
 					Package: "numpy",
@@ -543,7 +543,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 				Null:              Bool(true),
 			},
 		}
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Packages = []ProcedurePackage{
 			{
 				Package: "numpy",
@@ -579,7 +579,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 		opts.Comment = String("test comment")
 		opts.ExecuteAs = ExecuteAsPointer(ExecuteAsCaller)
 		opts.ProcedureDefinition = String("import numpy as np")
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE SECURE PROCEDURE %s ("i" int DEFAULT 1) COPY GRANTS RETURNS VARIANT NULL LANGUAGE PYTHON STRICT IMMUTABLE RUNTIME_VERSION = '3.8' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) COMMENT = 'test comment' EXECUTE AS CALLER AS import numpy as np`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE SECURE PROCEDURE %s ("i" int DEFAULT 1) COPY GRANTS RETURNS VARIANT NULL LANGUAGE PYTHON STRICT IMMUTABLE RUNTIME_VERSION = '3.9' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) COMMENT = 'test comment' EXECUTE AS CALLER AS import numpy as np`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
 	})
 
 	t.Run("all options", func(t *testing.T) {
@@ -600,7 +600,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 				Null:           Bool(true),
 			},
 		}
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Packages = []ProcedurePackage{
 			{
 				Package: "numpy",
@@ -636,7 +636,7 @@ func TestProcedures_CreateForPython(t *testing.T) {
 		opts.Comment = String("test comment")
 		opts.ExecuteAs = ExecuteAsPointer(ExecuteAsCaller)
 		opts.ProcedureDefinition = String("import numpy as np")
-		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE SECURE PROCEDURE %s ("i" NUMBER(36, 2) DEFAULT 1) COPY GRANTS RETURNS VARIANT NULL LANGUAGE PYTHON STRICT IMMUTABLE RUNTIME_VERSION = '3.8' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) COMMENT = 'test comment' EXECUTE AS CALLER AS import numpy as np`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `CREATE OR REPLACE SECURE PROCEDURE %s ("i" NUMBER(36, 2) DEFAULT 1) COPY GRANTS RETURNS VARIANT NULL LANGUAGE PYTHON STRICT IMMUTABLE RUNTIME_VERSION = '3.9' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' EXTERNAL_ACCESS_INTEGRATIONS = ("ext_integration") SECRETS = ('variable1' = %s, 'variable2' = %s) COMMENT = 'test comment' EXECUTE AS CALLER AS import numpy as np`, id.FullyQualifiedName(), secretId.FullyQualifiedName(), secretId2.FullyQualifiedName())
 	})
 }
 
@@ -1755,7 +1755,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 		opts.Returns = ProcedureReturns{
 			Table: &ProcedureReturnsTable{},
 		}
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Packages = []ProcedurePackage{
 			{
 				Package: "snowflake-snowpark-python",
@@ -1763,7 +1763,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 		}
 		opts.Handler = "udf"
 		opts.ProcedureName = id
-		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE () RETURNS TABLE () LANGUAGE PYTHON RUNTIME_VERSION = '3.8' PACKAGES = ('snowflake-snowpark-python') HANDLER = 'udf' CALL %s ()`, id.FullyQualifiedName(), id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE () RETURNS TABLE () LANGUAGE PYTHON RUNTIME_VERSION = '3.9' PACKAGES = ('snowflake-snowpark-python') HANDLER = 'udf' CALL %s ()`, id.FullyQualifiedName(), id.FullyQualifiedName())
 	})
 
 	// TODO [SNOW-1348106]: remove with old procedure removal for V1
@@ -1782,7 +1782,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 				Null:              Bool(true),
 			},
 		}
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Packages = []ProcedurePackage{
 			{
 				Package: "numpy",
@@ -1813,7 +1813,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 		opts.ProcedureName = id
 		opts.ScriptingVariable = String(":ret")
 		opts.CallArguments = []string{"1"}
-		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE ("i" int DEFAULT 1) RETURNS VARIANT NULL LANGUAGE PYTHON STRICT RUNTIME_VERSION = '3.8' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' AS 'import numpy as np' , %s (x, y) AS (select m.album_ID, m.album_name, b.band_name from music_albums) CALL %s (1) INTO :ret`, id.FullyQualifiedName(), cte.FullyQualifiedName(), id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE ("i" int DEFAULT 1) RETURNS VARIANT NULL LANGUAGE PYTHON STRICT RUNTIME_VERSION = '3.9' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' AS 'import numpy as np' , %s (x, y) AS (select m.album_ID, m.album_name, b.band_name from music_albums) CALL %s (1) INTO :ret`, id.FullyQualifiedName(), cte.FullyQualifiedName(), id.FullyQualifiedName())
 	})
 
 	t.Run("all options", func(t *testing.T) {
@@ -1831,7 +1831,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 				Null:           Bool(true),
 			},
 		}
-		opts.RuntimeVersion = "3.8"
+		opts.RuntimeVersion = "3.9"
 		opts.Packages = []ProcedurePackage{
 			{
 				Package: "numpy",
@@ -1862,7 +1862,7 @@ func TestProcedures_CreateAndCallForPython(t *testing.T) {
 		opts.ProcedureName = id
 		opts.ScriptingVariable = String(":ret")
 		opts.CallArguments = []string{"1"}
-		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE ("i" NUMBER(36, 2) DEFAULT 1) RETURNS VARIANT NULL LANGUAGE PYTHON STRICT RUNTIME_VERSION = '3.8' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' AS 'import numpy as np' , %s (x, y) AS (select m.album_ID, m.album_name, b.band_name from music_albums) CALL %s (1) INTO :ret`, id.FullyQualifiedName(), cte.FullyQualifiedName(), id.FullyQualifiedName())
+		assertOptsValidAndSQLEquals(t, opts, `WITH %s AS PROCEDURE ("i" NUMBER(36, 2) DEFAULT 1) RETURNS VARIANT NULL LANGUAGE PYTHON STRICT RUNTIME_VERSION = '3.9' PACKAGES = ('numpy', 'pandas') IMPORTS = ('numpy', 'pandas') HANDLER = 'udf' AS 'import numpy as np' , %s (x, y) AS (select m.album_ID, m.album_name, b.band_name from music_albums) CALL %s (1) INTO :ret`, id.FullyQualifiedName(), cte.FullyQualifiedName(), id.FullyQualifiedName())
 	})
 }
 

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -732,7 +732,7 @@ func TestInt_Functions(t *testing.T) {
 			WithComment("comment").
 			WithImports([]sdk.FunctionImportRequest{*sdk.NewFunctionImportRequest().WithImport(tmpPythonFunction.PythonModuleLocation())}).
 			WithPackages([]sdk.FunctionPackageRequest{
-				*sdk.NewFunctionPackageRequest().WithPackage("absl-py==0.10.0"),
+				*sdk.NewFunctionPackageRequest().WithPackage("absl-py==0.12.0"),
 				*sdk.NewFunctionPackageRequest().WithPackage("about-time==4.2.1"),
 			}).
 			WithExternalAccessIntegrations([]sdk.AccountObjectIdentifier{externalAccessIntegration}).
@@ -789,8 +789,8 @@ func TestInt_Functions(t *testing.T) {
 			}).
 			HasHandler(funcName).
 			HasRuntimeVersion(testvars.PythonRuntime).
-			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
-			HasExactlyPackagesInAnyOrder("absl-py==0.10.0", "about-time==4.2.1").
+			HasPackages(`['absl-py==0.12.0','about-time==4.2.1']`).
+			HasExactlyPackagesInAnyOrder("absl-py==0.12.0", "about-time==4.2.1").
 			HasTargetPathNil().
 			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().
@@ -895,7 +895,7 @@ func TestInt_Functions(t *testing.T) {
 			WithReturnResultsBehavior(sdk.ReturnResultsBehaviorImmutable).
 			WithComment("comment").
 			WithPackages([]sdk.FunctionPackageRequest{
-				*sdk.NewFunctionPackageRequest().WithPackage("absl-py==0.10.0"),
+				*sdk.NewFunctionPackageRequest().WithPackage("absl-py==0.12.0"),
 				*sdk.NewFunctionPackageRequest().WithPackage("about-time==4.2.1"),
 			}).
 			WithExternalAccessIntegrations([]sdk.AccountObjectIdentifier{externalAccessIntegration}).
@@ -952,8 +952,8 @@ func TestInt_Functions(t *testing.T) {
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
 			HasRuntimeVersion(testvars.PythonRuntime).
-			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
-			HasExactlyPackagesInAnyOrder("about-time==4.2.1", "absl-py==0.10.0").
+			HasPackages(`['absl-py==0.12.0','about-time==4.2.1']`).
+			HasExactlyPackagesInAnyOrder("about-time==4.2.1", "absl-py==0.12.0").
 			HasTargetPathNil().
 			HasNormalizedTargetPathNil().
 			HasInstalledPackagesNotEmpty().

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/objectparametersassert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -646,7 +647,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, funcName).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithFunctionDefinitionWrapped(definition)
 
@@ -696,7 +697,7 @@ func TestInt_Functions(t *testing.T) {
 			HasImports(`[]`).
 			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(funcName).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`[]`).
 			HasExactlyPackagesInAnyOrder().
 			HasTargetPathNil().
@@ -721,7 +722,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, funcName).
 			WithOrReplace(true).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -787,7 +788,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(funcName).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0", "about-time==4.2.1").
 			HasTargetPathNil().
@@ -810,7 +811,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, tmpPythonFunction.PythonHandler()).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithImports([]sdk.FunctionImportRequest{*sdk.NewFunctionImportRequest().WithImport(tmpPythonFunction.PythonModuleLocation())})
 
@@ -862,7 +863,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`[]`).
 			HasExactlyPackagesInAnyOrder().
 			HasTargetPathNil().
@@ -885,7 +886,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, tmpPythonFunction.PythonHandler()).
 			WithOrReplace(true).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -950,7 +951,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasExactlyPackagesInAnyOrder("about-time==4.2.1", "absl-py==0.10.0").
 			HasTargetPathNil().
@@ -1954,7 +1955,7 @@ func TestInt_Functions(t *testing.T) {
 		err := client.Functions.CreateForPython(ctx, sdk.NewCreateForPythonFunctionRequest(
 			id,
 			*sdk.NewFunctionReturnsRequest().WithResultDataType(*sdk.NewFunctionReturnsResultDataTypeRequest(nil).WithResultDataTypeOld(sdk.DataTypeVariant)),
-			"3.9",
+			testvars.PythonRuntime,
 			"add",
 		).
 			WithArguments(args).
@@ -2023,7 +2024,7 @@ func TestInt_Functions(t *testing.T) {
 			err = client.Functions.CreateForPython(ctx, sdk.NewCreateForPythonFunctionRequest(
 				id,
 				*sdk.NewFunctionReturnsRequest().WithResultDataType(*sdk.NewFunctionReturnsResultDataTypeRequest(dataType)),
-				"3.9",
+				testvars.PythonRuntime,
 				funcName,
 			).
 				WithArguments(args).

--- a/pkg/sdk/testint/functions_integration_test.go
+++ b/pkg/sdk/testint/functions_integration_test.go
@@ -646,7 +646,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.8", funcName).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithFunctionDefinitionWrapped(definition)
 
@@ -696,7 +696,7 @@ func TestInt_Functions(t *testing.T) {
 			HasImports(`[]`).
 			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(funcName).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`[]`).
 			HasExactlyPackagesInAnyOrder().
 			HasTargetPathNil().
@@ -721,7 +721,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.8", funcName).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", funcName).
 			WithOrReplace(true).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -787,7 +787,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(funcName).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0", "about-time==4.2.1").
 			HasTargetPathNil().
@@ -810,7 +810,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.8", tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", tmpPythonFunction.PythonHandler()).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithImports([]sdk.FunctionImportRequest{*sdk.NewFunctionImportRequest().WithImport(tmpPythonFunction.PythonModuleLocation())})
 
@@ -862,7 +862,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`[]`).
 			HasExactlyPackagesInAnyOrder().
 			HasTargetPathNil().
@@ -885,7 +885,7 @@ func TestInt_Functions(t *testing.T) {
 		dt := sdk.NewFunctionReturnsResultDataTypeRequest(dataType)
 		returns := sdk.NewFunctionReturnsRequest().WithResultDataType(*dt)
 		argument := sdk.NewFunctionArgumentRequest(argName, dataType)
-		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.8", tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonFunctionRequest(id.SchemaObjectId(), *returns, "3.9", tmpPythonFunction.PythonHandler()).
 			WithOrReplace(true).
 			WithArguments([]sdk.FunctionArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -950,7 +950,7 @@ func TestInt_Functions(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['absl-py==0.10.0','about-time==4.2.1']`).
 			HasExactlyPackagesInAnyOrder("about-time==4.2.1", "absl-py==0.10.0").
 			HasTargetPathNil().
@@ -1954,7 +1954,7 @@ func TestInt_Functions(t *testing.T) {
 		err := client.Functions.CreateForPython(ctx, sdk.NewCreateForPythonFunctionRequest(
 			id,
 			*sdk.NewFunctionReturnsRequest().WithResultDataType(*sdk.NewFunctionReturnsResultDataTypeRequest(nil).WithResultDataTypeOld(sdk.DataTypeVariant)),
-			"3.8",
+			"3.9",
 			"add",
 		).
 			WithArguments(args).
@@ -2023,7 +2023,7 @@ func TestInt_Functions(t *testing.T) {
 			err = client.Functions.CreateForPython(ctx, sdk.NewCreateForPythonFunctionRequest(
 				id,
 				*sdk.NewFunctionReturnsRequest().WithResultDataType(*sdk.NewFunctionReturnsResultDataTypeRequest(dataType)),
-				"3.8",
+				"3.9",
 				funcName,
 			).
 				WithArguments(args).

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -619,7 +619,7 @@ func TestInt_Procedures(t *testing.T) {
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, funcName).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, funcName).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithProcedureDefinitionWrapped(definition)
 
@@ -665,7 +665,7 @@ func TestInt_Procedures(t *testing.T) {
 			HasImports(`[]`).
 			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(funcName).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['snowflake-snowpark-python==1.14.0']`).
 			HasExactlyPackagesInAnyOrder().
 			HasSnowparkVersion("1.14.0").
@@ -697,7 +697,7 @@ func TestInt_Procedures(t *testing.T) {
 			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
 		}
 
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, funcName).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, funcName).
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -755,7 +755,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(funcName).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
 			HasSnowparkVersion("1.14.0").
@@ -782,7 +782,7 @@ func TestInt_Procedures(t *testing.T) {
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, tmpPythonFunction.PythonHandler()).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithImports([]sdk.ProcedureImportRequest{*sdk.NewProcedureImportRequest(tmpPythonFunction.PythonModuleLocation())})
 
@@ -830,7 +830,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['snowflake-snowpark-python==1.14.0']`).
 			HasExactlyPackagesInAnyOrder().
 			HasSnowparkVersion("1.14.0").
@@ -860,7 +860,7 @@ func TestInt_Procedures(t *testing.T) {
 			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
 		}
 
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, tmpPythonFunction.PythonHandler()).
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -917,7 +917,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.8").
+			HasRuntimeVersion("3.9").
 			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
 			HasSnowparkVersion("1.14.0").
@@ -1699,7 +1699,7 @@ def joblib_multiprocessing(session, i):
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python"),
 			*sdk.NewProcedurePackageRequest("joblib"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, "joblib_multiprocessing").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "joblib_multiprocessing").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithProcedureDefinitionWrapped(definition)
@@ -1733,7 +1733,7 @@ def filter_by_role(session, table_name, role):
 		arg1 := sdk.NewProcedureArgumentRequest("table_name", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, "filter_by_role").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "filter_by_role").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinitionWrapped(definition)
@@ -2280,7 +2280,7 @@ def filter_by_role(session, table_name, role):
 			err = client.Procedures.CreateForPython(ctx, sdk.NewCreateForPythonProcedureRequest(
 				idWithArguments.SchemaObjectId(),
 				*sdk.NewProcedureReturnsRequest().WithResultDataType(*sdk.NewProcedureReturnsResultDataTypeRequest(dataType)),
-				"3.8",
+				"3.9",
 				packages,
 				procName,
 			).
@@ -2505,7 +2505,7 @@ def filter_by_role(session, name, role):
 		arg1 := sdk.NewProcedureArgumentRequest("name", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.8", packages, "filter_by_role").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "filter_by_role").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinitionWrapped(definition)
@@ -2674,7 +2674,7 @@ def filter_by_role(session, name, role):
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
 		ca := []string{fmt.Sprintf(`'%s'`, tid.FullyQualifiedName()), "'dev'"}
-		request := sdk.NewCreateAndCallForPythonProcedureRequest(name, *returns, "3.8", packages, "filter_by_role", name).
+		request := sdk.NewCreateAndCallForPythonProcedureRequest(name, *returns, "3.9", packages, "filter_by_role", name).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinition(definition).
 			WithCallArguments(ca)

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert/objectparametersassert"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
@@ -619,7 +620,7 @@ func TestInt_Procedures(t *testing.T) {
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, funcName).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, funcName).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithProcedureDefinitionWrapped(definition)
 
@@ -665,7 +666,7 @@ func TestInt_Procedures(t *testing.T) {
 			HasImports(`[]`).
 			HasExactlyImportsNormalizedInAnyOrder().
 			HasHandler(funcName).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['snowflake-snowpark-python==1.14.0']`).
 			HasExactlyPackagesInAnyOrder().
 			HasSnowparkVersion("1.14.0").
@@ -697,7 +698,7 @@ func TestInt_Procedures(t *testing.T) {
 			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
 		}
 
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, funcName).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, funcName).
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -755,7 +756,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(funcName).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
 			HasSnowparkVersion("1.14.0").
@@ -782,7 +783,7 @@ func TestInt_Procedures(t *testing.T) {
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, tmpPythonFunction.PythonHandler()).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithImports([]sdk.ProcedureImportRequest{*sdk.NewProcedureImportRequest(tmpPythonFunction.PythonModuleLocation())})
 
@@ -830,7 +831,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['snowflake-snowpark-python==1.14.0']`).
 			HasExactlyPackagesInAnyOrder().
 			HasSnowparkVersion("1.14.0").
@@ -860,7 +861,7 @@ func TestInt_Procedures(t *testing.T) {
 			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
 		}
 
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, tmpPythonFunction.PythonHandler()).
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, tmpPythonFunction.PythonHandler()).
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithCopyGrants(true).
@@ -917,7 +918,7 @@ func TestInt_Procedures(t *testing.T) {
 				StageLocation: "~", PathOnStage: tmpPythonFunction.PythonFileName(),
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
-			HasRuntimeVersion("3.9").
+			HasRuntimeVersion(testvars.PythonRuntime).
 			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
 			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
 			HasSnowparkVersion("1.14.0").
@@ -1699,7 +1700,7 @@ def joblib_multiprocessing(session, i):
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python"),
 			*sdk.NewProcedurePackageRequest("joblib"),
 		}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "joblib_multiprocessing").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, "joblib_multiprocessing").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*argument}).
 			WithProcedureDefinitionWrapped(definition)
@@ -1733,7 +1734,7 @@ def filter_by_role(session, table_name, role):
 		arg1 := sdk.NewProcedureArgumentRequest("table_name", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "filter_by_role").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, "filter_by_role").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinitionWrapped(definition)
@@ -2280,7 +2281,7 @@ def filter_by_role(session, table_name, role):
 			err = client.Procedures.CreateForPython(ctx, sdk.NewCreateForPythonProcedureRequest(
 				idWithArguments.SchemaObjectId(),
 				*sdk.NewProcedureReturnsRequest().WithResultDataType(*sdk.NewProcedureReturnsResultDataTypeRequest(dataType)),
-				"3.9",
+				testvars.PythonRuntime,
 				packages,
 				procName,
 			).
@@ -2505,7 +2506,7 @@ def filter_by_role(session, name, role):
 		arg1 := sdk.NewProcedureArgumentRequest("name", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
-		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, "3.9", packages, "filter_by_role").
+		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, "filter_by_role").
 			WithOrReplace(true).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinitionWrapped(definition)
@@ -2674,7 +2675,7 @@ def filter_by_role(session, name, role):
 		arg2 := sdk.NewProcedureArgumentRequest("role", nil).WithArgDataTypeOld(sdk.DataTypeVARCHAR)
 		packages := []sdk.ProcedurePackageRequest{*sdk.NewProcedurePackageRequest("snowflake-snowpark-python")}
 		ca := []string{fmt.Sprintf(`'%s'`, tid.FullyQualifiedName()), "'dev'"}
-		request := sdk.NewCreateAndCallForPythonProcedureRequest(name, *returns, "3.9", packages, "filter_by_role", name).
+		request := sdk.NewCreateAndCallForPythonProcedureRequest(name, *returns, testvars.PythonRuntime, packages, "filter_by_role", name).
 			WithArguments([]sdk.ProcedureArgumentRequest{*arg1, *arg2}).
 			WithProcedureDefinition(definition).
 			WithCallArguments(ca)

--- a/pkg/sdk/testint/procedures_integration_test.go
+++ b/pkg/sdk/testint/procedures_integration_test.go
@@ -695,7 +695,7 @@ func TestInt_Procedures(t *testing.T) {
 		argument := sdk.NewProcedureArgumentRequest(argName, dataType)
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
-			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
+			*sdk.NewProcedurePackageRequest("absl-py==0.12.0"),
 		}
 
 		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, funcName).
@@ -757,8 +757,8 @@ func TestInt_Procedures(t *testing.T) {
 			}).
 			HasHandler(funcName).
 			HasRuntimeVersion(testvars.PythonRuntime).
-			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
-			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
+			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.12.0']`).
+			HasExactlyPackagesInAnyOrder("absl-py==0.12.0").
 			HasSnowparkVersion("1.14.0").
 			HasTargetPathNil().
 			HasNormalizedTargetPathNil().
@@ -858,7 +858,7 @@ func TestInt_Procedures(t *testing.T) {
 		argument := sdk.NewProcedureArgumentRequest(argName, dataType)
 		packages := []sdk.ProcedurePackageRequest{
 			*sdk.NewProcedurePackageRequest("snowflake-snowpark-python==1.14.0"),
-			*sdk.NewProcedurePackageRequest("absl-py==0.10.0"),
+			*sdk.NewProcedurePackageRequest("absl-py==0.12.0"),
 		}
 
 		request := sdk.NewCreateForPythonProcedureRequest(id.SchemaObjectId(), *returns, testvars.PythonRuntime, packages, tmpPythonFunction.PythonHandler()).
@@ -919,8 +919,8 @@ func TestInt_Procedures(t *testing.T) {
 			}).
 			HasHandler(tmpPythonFunction.PythonHandler()).
 			HasRuntimeVersion(testvars.PythonRuntime).
-			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.10.0']`).
-			HasExactlyPackagesInAnyOrder("absl-py==0.10.0").
+			HasPackages(`['snowflake-snowpark-python==1.14.0','absl-py==0.12.0']`).
+			HasExactlyPackagesInAnyOrder("absl-py==0.12.0").
 			HasSnowparkVersion("1.14.0").
 			HasTargetPathNil().
 			HasNormalizedTargetPathNil().

--- a/pkg/testacc/function_python_acceptance_test.go
+++ b/pkg/testacc/function_python_acceptance_test.go
@@ -35,9 +35,9 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 
 	definition := testClient().Function.SamplePythonDefinition(t, funcName, argName)
 
-	functionModel := model.FunctionPythonBasicInline("test", id, "3.8", dataType, funcName, definition).
+	functionModel := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
 		WithArgument(argName, dataType)
-	functionModelRenamed := model.FunctionPythonBasicInline("test", idWithChangedNameButTheSameDataType, "3.8", dataType, funcName, definition).
+	functionModelRenamed := model.FunctionPythonBasicInline("test", idWithChangedNameButTheSameDataType, "3.9", dataType, funcName, definition).
 		WithArgument(argName, dataType)
 
 	resource.Test(t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultFunctionComment).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasFunctionDefinitionString(definition).
 						HasFunctionLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -141,7 +141,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
 	definition := testClient().Function.SamplePythonDefinition(t, funcName, argName)
 
-	functionModel := model.FunctionPythonBasicInline("test", id, "3.8", dataType, funcName, definition).
+	functionModel := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
 		WithIsSecure(r.BooleanFalse).
 		WithArgument(argName, dataType).
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -158,7 +158,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 			"def": secretId2,
 		})
 
-	functionModelUpdateWithoutRecreation := model.FunctionPythonBasicInline("test", id, "3.8", dataType, funcName, definition).
+	functionModelUpdateWithoutRecreation := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
 		WithIsSecure(r.BooleanFalse).
 		WithArgument(argName, dataType).
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -189,7 +189,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 					resourceassert.FunctionPythonResource(t, functionModel.ResourceReference()).
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasFunctionDefinitionString(definition).
 						HasCommentString("some comment").
 						HasFunctionLanguageString("PYTHON").
@@ -227,7 +227,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 					resourceassert.FunctionPythonResource(t, functionModelUpdateWithoutRecreation.ResourceReference()).
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasFunctionDefinitionString(definition).
 						HasCommentString("some other comment").
 						HasFunctionLanguageString("PYTHON").

--- a/pkg/testacc/function_python_acceptance_test.go
+++ b/pkg/testacc/function_python_acceptance_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/importchecks"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -35,9 +36,9 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 
 	definition := testClient().Function.SamplePythonDefinition(t, funcName, argName)
 
-	functionModel := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
+	functionModel := model.FunctionPythonBasicInline("test", id, testvars.PythonRuntime, dataType, funcName, definition).
 		WithArgument(argName, dataType)
-	functionModelRenamed := model.FunctionPythonBasicInline("test", idWithChangedNameButTheSameDataType, "3.9", dataType, funcName, definition).
+	functionModelRenamed := model.FunctionPythonBasicInline("test", idWithChangedNameButTheSameDataType, testvars.PythonRuntime, dataType, funcName, definition).
 		WithArgument(argName, dataType)
 
 	resource.Test(t, resource.TestCase{
@@ -56,7 +57,7 @@ func TestAcc_FunctionPython_InlineBasic(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultFunctionComment).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasFunctionDefinitionString(definition).
 						HasFunctionLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -141,7 +142,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 	id := testClient().Ids.RandomSchemaObjectIdentifierWithArgumentsNewDataTypes(dataType)
 	definition := testClient().Function.SamplePythonDefinition(t, funcName, argName)
 
-	functionModel := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
+	functionModel := model.FunctionPythonBasicInline("test", id, testvars.PythonRuntime, dataType, funcName, definition).
 		WithIsSecure(r.BooleanFalse).
 		WithArgument(argName, dataType).
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -158,7 +159,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 			"def": secretId2,
 		})
 
-	functionModelUpdateWithoutRecreation := model.FunctionPythonBasicInline("test", id, "3.9", dataType, funcName, definition).
+	functionModelUpdateWithoutRecreation := model.FunctionPythonBasicInline("test", id, testvars.PythonRuntime, dataType, funcName, definition).
 		WithIsSecure(r.BooleanFalse).
 		WithArgument(argName, dataType).
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
@@ -189,7 +190,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 					resourceassert.FunctionPythonResource(t, functionModel.ResourceReference()).
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasFunctionDefinitionString(definition).
 						HasCommentString("some comment").
 						HasFunctionLanguageString("PYTHON").
@@ -227,7 +228,7 @@ func TestAcc_FunctionPython_InlineFull(t *testing.T) {
 					resourceassert.FunctionPythonResource(t, functionModelUpdateWithoutRecreation.ResourceReference()).
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasFunctionDefinitionString(definition).
 						HasCommentString("some other comment").
 						HasFunctionLanguageString("PYTHON").

--- a/pkg/testacc/procedure_python_acceptance_test.go
+++ b/pkg/testacc/procedure_python_acceptance_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/importchecks"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
@@ -56,7 +57,7 @@ func TestAcc_ProcedurePython_InlineBasic(t *testing.T) {
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultProcedureComment).
 						HasImportsLength(0).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -153,7 +154,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 			"abc": secretId,
 			"def": secretId2,
 		}).
-		WithRuntimeVersion("3.9").
+		WithRuntimeVersion(testvars.PythonRuntime).
 		WithIsSecure("false").
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
 		WithExecuteAs(string(sdk.ExecuteAsCaller)).
@@ -171,7 +172,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 		WithSecrets(map[string]sdk.SchemaObjectIdentifier{
 			"def": secretId2,
 		}).
-		WithRuntimeVersion("3.9").
+		WithRuntimeVersion(testvars.PythonRuntime).
 		WithIsSecure("false").
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
 		WithExecuteAs(string(sdk.ExecuteAsOwner)).
@@ -193,7 +194,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasCommentString("some comment").
 						HasProcedureLanguageString("PYTHON").
@@ -234,7 +235,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasCommentString("some other comment").
 						HasProcedureLanguageString("PYTHON").
@@ -285,7 +286,7 @@ func TestAcc_ProcedurePython_ImportsDiffSuppression(t *testing.T) {
 			sdk.NormalizedPath{StageLocation: stage.ID().FullyQualifiedName(), PathOnStage: tmpPythonFunction2.PythonFileName()},
 		).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.9").
+		WithRuntimeVersion(testvars.PythonRuntime).
 		WithIsSecure("false")
 
 	resource.Test(t, resource.TestCase{
@@ -303,7 +304,7 @@ func TestAcc_ProcedurePython_ImportsDiffSuppression(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -375,14 +376,14 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 		WithArgument(argName, dataType).
 		WithImports(importsBefore...).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.9").
+		WithRuntimeVersion(testvars.PythonRuntime).
 		WithIsSecure("false")
 
 	procedureModelWithUpdatedImports := model.ProcedurePythonBasicInline("w", id, dataType, funcName, definition).
 		WithArgument(argName, dataType).
 		WithImports(importsAfter...).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.9").
+		WithRuntimeVersion(testvars.PythonRuntime).
 		WithIsSecure("false")
 
 	resource.Test(t, resource.TestCase{
@@ -400,7 +401,7 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -422,7 +423,7 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.9").
+						HasRuntimeVersionString(testvars.PythonRuntime).
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),

--- a/pkg/testacc/procedure_python_acceptance_test.go
+++ b/pkg/testacc/procedure_python_acceptance_test.go
@@ -56,7 +56,7 @@ func TestAcc_ProcedurePython_InlineBasic(t *testing.T) {
 						HasIsSecureString(r.BooleanDefault).
 						HasCommentString(sdk.DefaultProcedureComment).
 						HasImportsLength(0).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -153,7 +153,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 			"abc": secretId,
 			"def": secretId2,
 		}).
-		WithRuntimeVersion("3.8").
+		WithRuntimeVersion("3.9").
 		WithIsSecure("false").
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
 		WithExecuteAs(string(sdk.ExecuteAsCaller)).
@@ -171,7 +171,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 		WithSecrets(map[string]sdk.SchemaObjectIdentifier{
 			"def": secretId2,
 		}).
-		WithRuntimeVersion("3.8").
+		WithRuntimeVersion("3.9").
 		WithIsSecure("false").
 		WithNullInputBehavior(string(sdk.NullInputBehaviorCalledOnNullInput)).
 		WithExecuteAs(string(sdk.ExecuteAsOwner)).
@@ -193,7 +193,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasCommentString("some comment").
 						HasProcedureLanguageString("PYTHON").
@@ -234,7 +234,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasCommentString("some other comment").
 						HasProcedureLanguageString("PYTHON").
@@ -285,7 +285,7 @@ func TestAcc_ProcedurePython_ImportsDiffSuppression(t *testing.T) {
 			sdk.NormalizedPath{StageLocation: stage.ID().FullyQualifiedName(), PathOnStage: tmpPythonFunction2.PythonFileName()},
 		).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.8").
+		WithRuntimeVersion("3.9").
 		WithIsSecure("false")
 
 	resource.Test(t, resource.TestCase{
@@ -303,7 +303,7 @@ func TestAcc_ProcedurePython_ImportsDiffSuppression(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -375,14 +375,14 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 		WithArgument(argName, dataType).
 		WithImports(importsBefore...).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.8").
+		WithRuntimeVersion("3.9").
 		WithIsSecure("false")
 
 	procedureModelWithUpdatedImports := model.ProcedurePythonBasicInline("w", id, dataType, funcName, definition).
 		WithArgument(argName, dataType).
 		WithImports(importsAfter...).
 		WithSnowparkPackage("1.14.0").
-		WithRuntimeVersion("3.8").
+		WithRuntimeVersion("3.9").
 		WithIsSecure("false")
 
 	resource.Test(t, resource.TestCase{
@@ -400,7 +400,7 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),
@@ -422,7 +422,7 @@ func TestAcc_ProcedurePython_ChangeImports(t *testing.T) {
 						HasNameString(id.Name()).
 						HasIsSecureString(r.BooleanFalse).
 						HasImportsLength(2).
-						HasRuntimeVersionString("3.8").
+						HasRuntimeVersionString("3.9").
 						HasProcedureDefinitionString(definition).
 						HasProcedureLanguageString("PYTHON").
 						HasFullyQualifiedNameString(id.FullyQualifiedName()),

--- a/pkg/testacc/procedure_python_acceptance_test.go
+++ b/pkg/testacc/procedure_python_acceptance_test.go
@@ -148,7 +148,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 			sdk.NormalizedPath{StageLocation: "~", PathOnStage: tmpPythonFunction2.PythonFileName()},
 		).
 		WithSnowparkPackage("1.14.0").
-		WithPackages("absl-py==0.10.0").
+		WithPackages("absl-py==0.12.0").
 		WithExternalAccessIntegrations(externalAccessIntegration, externalAccessIntegration2).
 		WithSecrets(map[string]sdk.SchemaObjectIdentifier{
 			"abc": secretId,
@@ -167,7 +167,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 			sdk.NormalizedPath{StageLocation: "~", PathOnStage: tmpPythonFunction2.PythonFileName()},
 		).
 		WithSnowparkPackage("1.14.0").
-		WithPackages("absl-py==0.10.0").
+		WithPackages("absl-py==0.12.0").
 		WithExternalAccessIntegrations(externalAccessIntegration).
 		WithSecrets(map[string]sdk.SchemaObjectIdentifier{
 			"def": secretId2,
@@ -203,7 +203,7 @@ func TestAcc_ProcedurePython_InlineFull(t *testing.T) {
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "secrets.#", "2")),
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "external_access_integrations.#", "2")),
 					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "packages.#", "1")),
-					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "packages.0", "absl-py==0.10.0")),
+					assert.Check(resource.TestCheckResourceAttr(procedureModel.ResourceReference(), "packages.0", "absl-py==0.12.0")),
 					resourceshowoutputassert.ProcedureShowOutput(t, procedureModel.ResourceReference()).
 						HasIsSecure(false),
 				),


### PR DESCRIPTION
Use 3.9 and 3.10 Python runtime instead of the decommissioned 3.8, as our integration and acceptance tests started to fail yesterday. Extracted common const for Python runtime for easier refactoring later.