### PR TITLE
chore: Use common setup and cleanup for acceptance tests - provider

### DIFF
--- a/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
+++ b/pkg/acceptance/bettertestspoc/assert/objectassert/gen/model.go
@@ -57,7 +57,7 @@ func ModelFromSdkObjectDetails(sdkObject genhelpers.SdkObjectDetails) SnowflakeO
 }
 
 func MapToSnowflakeObjectFieldAssertion(field genhelpers.Field) SnowflakeObjectFieldAssertion {
-	TypeWithoutPointerAndBrackets := strings.TrimLeft(field.ConcreteType, "*[]")
+	concreteTypeWithoutPtrAndBrackets := field.ConcreteTypeNoPointerNoArray()
 
 	mapper := genhelpers.Identity
 	if field.IsPointer() {
@@ -66,7 +66,7 @@ func MapToSnowflakeObjectFieldAssertion(field genhelpers.Field) SnowflakeObjectF
 	expectedValueMapper := genhelpers.Identity
 
 	// TODO [SNOW-1501905]: handle other mappings if needed
-	if TypeWithoutPointerAndBrackets == "sdk.AccountObjectIdentifier" {
+	if concreteTypeWithoutPtrAndBrackets == "sdk.AccountObjectIdentifier" {
 		mapper = genhelpers.Name
 		if field.IsPointer() {
 			mapper = func(s string) string {
@@ -75,7 +75,7 @@ func MapToSnowflakeObjectFieldAssertion(field genhelpers.Field) SnowflakeObjectF
 		}
 		expectedValueMapper = genhelpers.Name
 	}
-	if TypeWithoutPointerAndBrackets == "sdk.SchemaObjectIdentifier" {
+	if concreteTypeWithoutPtrAndBrackets == "sdk.SchemaObjectIdentifier" {
 		mapper = genhelpers.FullyQualifiedName
 		if field.IsPointer() {
 			mapper = func(s string) string {

--- a/pkg/internal/genhelpers/struct_details_extractor.go
+++ b/pkg/internal/genhelpers/struct_details_extractor.go
@@ -35,7 +35,7 @@ func (f *Field) ConcreteTypeNoPointer() string {
 }
 
 func (f *Field) ConcreteTypeNoPointerNoArray() string {
-	concreteTypeNoPtrNoArr := strings.TrimLeft(f.ConcreteType, "*[]")
+	concreteTypeNoPtrNoArr := TypeWithoutPointerAndBrackets(f.ConcreteType)
 	return concreteTypeNoPtrNoArr
 }
 


### PR DESCRIPTION
Continuation of https://github.com/snowflakedb/terraform-provider-snowflake/pull/367,  https://github.com/snowflakedb/terraform-provider-snowflake/pull/3691, and https://github.com/snowflakedb/terraform-provider-snowflake/pull/3692.

- Move provider acceptance tests to use the `testacc` package setup
- Move one more resource-level tests (renaming hierarchies in Snowflake)
- Apply some fixes after review in https://github.com/snowflakedb/terraform-provider-snowflake/pull/3722

Next PRs:
- Removal of old acceptance tests setup
- Update contribution guidelines
- TODOs from https://github.com/snowflakedb/terraform-provider-snowflake/pull/3679
- architests
- test resources setup