### PR TITLE
feat: Add tag association support for services

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -65,8 +65,8 @@ Added a new preview data source for image repositories. See reference [docs](htt
 
 This feature will be marked as a stable feature in future releases. Breaking changes are expected, even without bumping the major version. To use this feature, add `snowflake_image_repositories_datasource` to `preview_features_enabled` field in the provider configuration.
 
-### *(new feature)* Managing tags for image repositories and compute pools
-The [snowflake_tag_association](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/tag_association) can now be used for managing tags in [image repositories](https://docs.snowflake.com/en/sql-reference/sql/create-image-repository) and [compute pools](https://docs.snowflake.com/en/sql-reference/sql/create-compute-pool).
+### *(new feature)* Managing tags for image repositories,  compute pools, and services
+The [snowflake_tag_association](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/tag_association) can now be used for managing tags in [image repositories](https://docs.snowflake.com/en/sql-reference/sql/create-image-repository), [compute pools](https://docs.snowflake.com/en/sql-reference/sql/create-compute-pool), and [services](https://docs.snowflake.com/en/sql-reference/sql/create-service).
 
 ### *(bugfix)* Fixed handling users' grants
 

--- a/pkg/sdk/tag_association_validations.go
+++ b/pkg/sdk/tag_association_validations.go
@@ -44,6 +44,7 @@ var (
 		ObjectTypeSessionPolicy,
 		ObjectTypePrivacyPolicy,
 		ObjectTypeProcedure,
+		ObjectTypeService,
 		ObjectTypeStage,
 		ObjectTypeStream,
 		ObjectTypeTable,

--- a/pkg/sdk/testint/compute_pools_integration_test.go
+++ b/pkg/sdk/testint/compute_pools_integration_test.go
@@ -237,9 +237,21 @@ func TestInt_ComputePools(t *testing.T) {
 		computePool, cleanup := testClientHelper().ComputePool.Create(t)
 		t.Cleanup(cleanup)
 
+		db, dbCleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
+		t.Cleanup(dbCleanup)
+
+		schema, schemaCleanup := testClientHelper().Schema.CreateSchemaInDatabase(t, db.ID())
+		t.Cleanup(schemaCleanup)
+
+		id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID())
+		service, serviceCleanup := testClientHelper().Service.CreateWithId(t, computePool.ID(), id)
+		t.Cleanup(serviceCleanup)
+
 		err := client.ComputePools.Alter(ctx, sdk.NewAlterComputePoolRequest(computePool.ID()).WithStopAll(true))
 		require.NoError(t, err)
-		// TODO (SNOW-2081739): Add assertions to check that all services are stopped.
+
+		_, err = client.Services.ShowByID(ctx, service.ID())
+		require.ErrorIs(t, err, sdk.ErrObjectNotFound)
 	})
 	t.Run("describe", func(t *testing.T) {
 		computePool, funcCleanup := testClientHelper().ComputePool.Create(t)

--- a/pkg/sdk/testint/tags_integration_test.go
+++ b/pkg/sdk/testint/tags_integration_test.go
@@ -940,6 +940,29 @@ func TestInt_TagsAssociations(t *testing.T) {
 				return client.ImageRepositories.Alter(ctx, sdk.NewAlterImageRepositoryRequest(id).WithUnsetTags(tags))
 			},
 		},
+		{
+			name:       "Service",
+			objectType: sdk.ObjectTypeService,
+			setupObject: func() (IDProvider[sdk.SchemaObjectIdentifier], func()) {
+				computePool, computePoolCleanup := testClientHelper().ComputePool.Create(t)
+				t.Cleanup(computePoolCleanup)
+
+				db, dbCleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
+				t.Cleanup(dbCleanup)
+
+				schema, schemaCleanup := testClientHelper().Schema.CreateSchemaInDatabase(t, db.ID())
+				t.Cleanup(schemaCleanup)
+
+				id := testClientHelper().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID())
+				return testClientHelper().Service.CreateWithId(t, computePool.ID(), id)
+			},
+			setTags: func(id sdk.SchemaObjectIdentifier, tags []sdk.TagAssociation) error {
+				return client.Services.Alter(ctx, sdk.NewAlterServiceRequest(id).WithSetTags(tags))
+			},
+			unsetTags: func(id sdk.SchemaObjectIdentifier, tags []sdk.ObjectIdentifier) error {
+				return client.Services.Alter(ctx, sdk.NewAlterServiceRequest(id).WithUnsetTags(tags))
+			},
+		},
 	}
 
 	for _, tc := range schemaObjectTestCases {


### PR DESCRIPTION
## Changes
- Add tag association support for services.
- Add a missing assertion to compute pool's STOP ALL test.

## TODO
- Service resource and data source.
- EXECUTE JOB SDK part.
