### PR TITLE
chore: Add an example of recreating the pipe on changing stage attributes

### DIFF
--- a/docs/resources/pipe.md
+++ b/docs/resources/pipe.md
@@ -11,34 +11,53 @@ description: |-
 
 ~> **Note** Right now, changes for the `integration` field are not detected. This will be resolved in the [upcoming refactoring](https://github.com/snowflakedb/terraform-provider-snowflake/blob/main/ROADMAP.md#preparing-essential-ga-objects-for-the-provider-v1). For now, please try to use the [replace_triggered_by](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by) HCL meta-argument.
 
+
+
 ## Example Usage
 
 ```terraform
-resource "snowflake_stage" "inbound" {
-  name                = "stage"
-  url                 = "s3://com.example.bucket/prefix"
-  database            = "db"
-  schema              = "schema"
-  storage_integration = "storage_integration"
-}
-
 resource "snowflake_pipe" "pipe" {
-  database = snowflake_stage.inbound.database
-  schema   = snowflake_stage.inbound.schema
-  name     = "pipe"
+  database = snowflake_database.database.name
+  schema   = snowflake_schema.schema.name
+  name     = "PIPE"
 
   comment = "A pipe."
 
-  copy_statement = "copy into mytable from @${snowflake_stage.inbound.name}"
+  copy_statement = "copy into ${snowflake_table.table.fully_qualified_name} from @${snowflake_stage.stage.fully_qualified_name}"
   auto_ingest    = false
 
   aws_sns_topic_arn    = "..."
   notification_channel = "..."
+}
 
+
+# Recreate the pipe when any of the cloud parameters of the referenced stage change.
+# Read more at https://docs.snowflake.com/en/user-guide/data-load-snowpipe-manage#changing-the-cloud-parameters-of-the-referenced-stage.
+resource "snowflake_stage" "stage" {
+  database = snowflake_database.database.name
+  schema   = snowflake_schema.schema.name
+  name     = "STAGE"
+
+  url                 = "s3://com.example.bucket/prefix"
+  storage_integration = snowflake_storage_integration.storage_integration.name
+  encryption          = "TYPE = 'NONE'"
+}
+
+resource "snowflake_pipe" "pipe_with_stage_change_trigger" {
+  database = snowflake_stage.stage.database
+  schema   = snowflake_stage.stage.schema
+  name     = "PIPE_WITH_STAGE_CHANGE_TRIGGER"
+
+  copy_statement = "copy into ${snowflake_table.table.fully_qualified_name} from @${snowflake_stage.stage.fully_qualified_name}"
+
+  # Use the replace_triggered_by meta-argument to recreate the pipe when any of the referenced attributes changes.
+  # When the referenced attributes are added to or removed from the stage configuration, the pipe will also be recreated.
+  # Read more at https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by.
   lifecycle {
     replace_triggered_by = [
-      # https://docs.snowflake.com/en/user-guide/data-load-snowpipe-manage#changing-the-cloud-parameters-of-the-referenced-stage
-      snowflake_stage.inbound,
+      snowflake_stage.stage.url,
+      snowflake_stage.stage.storage_integration,
+      snowflake_stage.stage.encryption,
     ]
   }
 }

--- a/examples/resources/snowflake_pipe/resource.tf
+++ b/examples/resources/snowflake_pipe/resource.tf
@@ -1,13 +1,45 @@
 resource "snowflake_pipe" "pipe" {
-  database = "db"
-  schema   = "schema"
-  name     = "pipe"
+  database = snowflake_database.database.name
+  schema   = snowflake_schema.schema.name
+  name     = "PIPE"
 
   comment = "A pipe."
 
-  copy_statement = "copy into mytable from @mystage"
+  copy_statement = "copy into ${snowflake_table.table.fully_qualified_name} from @${snowflake_stage.stage.fully_qualified_name}"
   auto_ingest    = false
 
   aws_sns_topic_arn    = "..."
   notification_channel = "..."
+}
+
+
+# Recreate the pipe when any of the cloud parameters of the referenced stage change.
+# Read more at https://docs.snowflake.com/en/user-guide/data-load-snowpipe-manage#changing-the-cloud-parameters-of-the-referenced-stage.
+resource "snowflake_stage" "stage" {
+  database = snowflake_database.database.name
+  schema   = snowflake_schema.schema.name
+  name     = "STAGE"
+
+  url                 = "s3://com.example.bucket/prefix"
+  storage_integration = snowflake_storage_integration.storage_integration.name
+  encryption          = "TYPE = 'NONE'"
+}
+
+resource "snowflake_pipe" "pipe_with_stage_change_trigger" {
+  database = snowflake_stage.stage.database
+  schema   = snowflake_stage.stage.schema
+  name     = "PIPE_WITH_STAGE_CHANGE_TRIGGER"
+
+  copy_statement = "copy into ${snowflake_table.table.fully_qualified_name} from @${snowflake_stage.stage.fully_qualified_name}"
+
+  # Use the replace_triggered_by meta-argument to recreate the pipe when any of the referenced attributes changes.
+  # When the referenced attributes are added to or removed from the stage configuration, the pipe will also be recreated.
+  # Read more at https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by.
+  lifecycle {
+    replace_triggered_by = [
+      snowflake_stage.stage.url,
+      snowflake_stage.stage.storage_integration,
+      snowflake_stage.stage.encryption,
+    ]
+  }
 }


### PR DESCRIPTION
This expands on the example for the `snowflake_pipe` resource:

- Shows setting up a pipe with a corresponding stage
- Forces the recreation of the pipe based on the stage changing

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->

n/a

## References
<!-- issues documentation links, etc  -->

none