### PR TITLE
docs: remove false attribute from snowflake_shared_database example

### DIFF
--- a/docs/resources/shared_database.md
+++ b/docs/resources/shared_database.md
@@ -46,12 +46,11 @@ resource "snowflake_shared_database" "test" {
 
 ## 2.2. Complete version (with every optional set)
 resource "snowflake_shared_database" "test" {
-  provider     = secondary_account
-  depends_on   = [snowflake_grant_privileges_to_share.test]
-  name         = snowflake_database.test.name # shared database should have the same as the "imported" one
-  is_transient = false
-  from_share   = "<primary_account_organization_name>.<primary_account_name>.${snowflake_share.test.name}"
-  comment      = "A shared database"
+  provider   = secondary_account
+  depends_on = [snowflake_grant_privileges_to_share.test]
+  name       = snowflake_database.test.name # shared database should have the same as the "imported" one
+  from_share = "<primary_account_organization_name>.<primary_account_name>.${snowflake_share.test.name}"
+  comment    = "A shared database"
 
   external_volume                               = "<external_volume_name>"
   catalog                                       = "<catalog_name>"

--- a/examples/resources/snowflake_shared_database/resource.tf
+++ b/examples/resources/snowflake_shared_database/resource.tf
@@ -28,12 +28,11 @@ resource "snowflake_shared_database" "test" {
 
 ## 2.2. Complete version (with every optional set)
 resource "snowflake_shared_database" "test" {
-  provider     = secondary_account
-  depends_on   = [snowflake_grant_privileges_to_share.test]
-  name         = snowflake_database.test.name # shared database should have the same as the "imported" one
-  is_transient = false
-  from_share   = "<primary_account_organization_name>.<primary_account_name>.${snowflake_share.test.name}"
-  comment      = "A shared database"
+  provider   = secondary_account
+  depends_on = [snowflake_grant_privileges_to_share.test]
+  name       = snowflake_database.test.name # shared database should have the same as the "imported" one
+  from_share = "<primary_account_organization_name>.<primary_account_name>.${snowflake_share.test.name}"
+  comment    = "A shared database"
 
   external_volume                               = "<external_volume_name>"
   catalog                                       = "<catalog_name>"


### PR DESCRIPTION
The snowflake_shared_database example includes the "is_transient" attribute in the resource definition even though this resource does not expose that attribute. This PR updates the example & doc to fix that.

Update: The previous PR (https://github.com/snowflakedb/terraform-provider-snowflake/pull/3743) was based on the main branch rather than dev; this PR uses the dev branch for the PR instead. 

## References

* https://github.com/snowflakedb/terraform-provider-snowflake/issues/3731