### PR TITLE
fix: Recreate Pipe when integration/error_integration changes

### DIFF
--- a/pkg/resources/pipe.go
+++ b/pkg/resources/pipe.go
@@ -65,6 +65,7 @@ var pipeSchema = map[string]*schema.Schema{
 	"integration": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		ForceNew:    true,
 		Description: "Specifies an integration for the pipe.",
 	},
 	"notification_channel": {
@@ -80,6 +81,7 @@ var pipeSchema = map[string]*schema.Schema{
 	"error_integration": {
 		Type:        schema.TypeString,
 		Optional:    true,
+		ForceNew:    true,
 		Description: "Specifies the name of the notification integration used for error notifications.",
 	},
 	FullyQualifiedNameAttributeName: schemas.FullyQualifiedNameSchema,


### PR DESCRIPTION
<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

When the Pipe `integration`/`error_integration` change, the resource should be recreated.

I have not tested this change myself — building, running tests, or actual usage — so not sure if there are other things in the codebase that need to be changed.

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
* [ ] Try creating a `snowflake_pipe`, modify the `integration`/`error_integration`, then confirm it forces a recreate

## References
<!-- issues documentation links, etc  -->

* Fixes https://github.com/snowflakedb/terraform-provider-snowflake/issues/2785
* https://docs.snowflake.com/en/sql-reference/sql/alter-pipe#usage-notes