### PR TITLE
fix: Fix external oauth integration issuer tests

### DIFF
--- a/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
+++ b/pkg/testacc/resource_external_oauth_integration_acceptance_test.go
@@ -428,7 +428,7 @@ func TestAcc_ExternalOauthIntegration_invalidAnyRoleMode(t *testing.T) {
 			"external_oauth_any_role_mode":                    config.StringVariable("invalid"),
 			"external_oauth_audience_list":                    config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_blocked_roles_list":               config.SetVariable(config.StringVariable("foo")),
-			"external_oauth_issuer":                           config.StringVariable("foo"),
+			"external_oauth_issuer":                           config.StringVariable(random.String()),
 			"external_oauth_jws_keys_url":                     config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_rsa_public_key":                   config.StringVariable("foo"),
 			"external_oauth_rsa_public_key_2":                 config.StringVariable("foo"),
@@ -465,7 +465,7 @@ func TestAcc_ExternalOauthIntegration_invalidSnowflakeUserMappingAttribute(t *te
 			"external_oauth_any_role_mode":                    config.StringVariable(string(sdk.ExternalOauthSecurityIntegrationAnyRoleModeDisable)),
 			"external_oauth_audience_list":                    config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_blocked_roles_list":               config.SetVariable(config.StringVariable("foo")),
-			"external_oauth_issuer":                           config.StringVariable("foo"),
+			"external_oauth_issuer":                           config.StringVariable(random.String()),
 			"external_oauth_jws_keys_url":                     config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_rsa_public_key":                   config.StringVariable("foo"),
 			"external_oauth_rsa_public_key_2":                 config.StringVariable("foo"),
@@ -502,7 +502,7 @@ func TestAcc_ExternalOauthIntegration_invalidOauthType(t *testing.T) {
 			"external_oauth_any_role_mode":                    config.StringVariable(string(sdk.ExternalOauthSecurityIntegrationAnyRoleModeDisable)),
 			"external_oauth_audience_list":                    config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_blocked_roles_list":               config.SetVariable(config.StringVariable("foo")),
-			"external_oauth_issuer":                           config.StringVariable("foo"),
+			"external_oauth_issuer":                           config.StringVariable(random.String()),
 			"external_oauth_jws_keys_url":                     config.SetVariable(config.StringVariable("foo")),
 			"external_oauth_rsa_public_key":                   config.StringVariable("foo"),
 			"external_oauth_rsa_public_key_2":                 config.StringVariable("foo"),
@@ -852,13 +852,13 @@ func TestAcc_ExternalOauthIntegration_WithQuotedName(t *testing.T) {
 func externalOauthIntegrationBasicConfig(name string) string {
 	return fmt.Sprintf(`
 resource "snowflake_external_oauth_integration" "test" {
-	name               = "%s"
+	name               = "%[1]s"
 	external_oauth_type                             = "CUSTOM"
 	enabled                                         = true
-	external_oauth_issuer                           = "issuer"
+	external_oauth_issuer                           = "%[2]s"
 	external_oauth_token_user_mapping_claim         = [ "foo" ]
 	external_oauth_snowflake_user_mapping_attribute = "EMAIL_ADDRESS"
 	external_oauth_jws_keys_url                     = [ "https://example.com" ]
 }
-`, name)
+`, name, random.String())
 }


### PR DESCRIPTION
To tackle the error:
```
=== RUN   TestAcc_ExternalOauthIntegration_migrateFromV0941_ensureSmoothUpgradeWithNewResourceId
    resource_external_oauth_integration_acceptance_test.go:788: running check destroy for resource snowflake_external_oauth_integration
    resource_external_oauth_integration_acceptance_test.go:783: Step 1/2 error: Error running apply: exit status 1

        Error: 003524 (22023): SQL execution error: An integration with the given issuer already exists for this account.

          with snowflake_external_oauth_integration.test,
          on terraform_plugin_test.tf line 14, in resource "snowflake_external_oauth_integration" "test":
          14: resource "snowflake_external_oauth_integration" "test" {

--- FAIL: TestAcc_ExternalOauthIntegration_migrateFromV0941_ensureSmoothUpgradeWithNewResourceId (4.71s)
```
All tests setting up the issuer use the random value now.