### PR TITLE
chore: Add tag propagation limitation to the tag resource documentation

### DIFF
--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -7,6 +7,8 @@ description: |-
 
 ~> **Required warehouse** For this resource, the provider now uses [tag references](https://docs.snowflake.com/en/sql-reference/functions/tag_references) to get information about masking policies attached to tags. This function requires a warehouse in the connection. Please, make sure you have either set a `DEFAULT_WAREHOUSE` for the user, or specified a warehouse in the provider configuration.
 
+~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This is resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
+
 # snowflake_tag (Resource)
 
 Resource used to manage tags. For more information, check [tag documentation](https://docs.snowflake.com/en/sql-reference/sql/create-tag). For assigning tags to Snowflake objects, see [tag_association resource](./tag_association).

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -7,7 +7,7 @@ description: |-
 
 ~> **Required warehouse** For this resource, the provider now uses [tag references](https://docs.snowflake.com/en/sql-reference/functions/tag_references) to get information about masking policies attached to tags. This function requires a warehouse in the connection. Please, make sure you have either set a `DEFAULT_WAREHOUSE` for the user, or specified a warehouse in the provider configuration.
 
-~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This is resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
+~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
 
 # snowflake_tag (Resource)
 

--- a/templates/resources/tag.md.tmpl
+++ b/templates/resources/tag.md.tmpl
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Required warehouse** For this resource, the provider now uses [tag references](https://docs.snowflake.com/en/sql-reference/functions/tag_references) to get information about masking policies attached to tags. This function requires a warehouse in the connection. Please, make sure you have either set a `DEFAULT_WAREHOUSE` for the user, or specified a warehouse in the provider configuration.
 
-~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This is resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
+~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
 
 # {{.Name}} ({{.Type}})
 

--- a/templates/resources/tag.md.tmpl
+++ b/templates/resources/tag.md.tmpl
@@ -11,6 +11,8 @@ description: |-
 
 ~> **Required warehouse** For this resource, the provider now uses [tag references](https://docs.snowflake.com/en/sql-reference/functions/tag_references) to get information about masking policies attached to tags. This function requires a warehouse in the connection. Please, make sure you have either set a `DEFAULT_WAREHOUSE` for the user, or specified a warehouse in the provider configuration.
 
+~> **Current limitations** Recently, the tags propagation was introduced (check [2025-05-14-tag-propagation](https://docs.snowflake.com/en/release-notes/2025/other/2025-05-14-tag-propagation)). This is resource is not currently supporting the `ON_CONFLICT` attribute and the tag allowed values ordering. If needed, use the [`snowflake_execute`](./execute) for the time-being. This limitation will be addressed in the next versions of the provider.
+
 # {{.Name}} ({{.Type}})
 
 {{ .Description | trimspace }}


### PR DESCRIPTION
Add tag propagation limitation to the tag resource documentation