### PR TITLE
chore: Adjust failing tests

### DIFF
--- a/pkg/sdk/testint/conversion_functions_integration_test.go
+++ b/pkg/sdk/testint/conversion_functions_integration_test.go
@@ -1,4 +1,4 @@
-//go:build !account_level_tests
+//go:build account_level_tests
 
 package testint
 

--- a/pkg/sdk/testint/grants_account_level_integration_test.go
+++ b/pkg/sdk/testint/grants_account_level_integration_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestInt_ShowGrants_To_Users(t *testing.T) {
+	t.Skip("TODO(SNOW-2081651): re-enable this if the test is still relevant without the BCR bundle update as now it's enabled by default in Snowflake")
 	secondaryTestClientHelper().BcrBundles.EnableBcrBundle(t, "2025_02")
 
 	t.Run("handles granteeName for account role granted to user", func(t *testing.T) {

--- a/pkg/testacc/resource_account_parameter_acceptance_test.go
+++ b/pkg/testacc/resource_account_parameter_acceptance_test.go
@@ -199,6 +199,7 @@ func TestAcc_AccountParameter_CSV_TIMESTAMP_FORMAT(t *testing.T) {
 }
 
 func TestAcc_AccountParameter_DISABLE_USER_PRIVILEGE_GRANTS(t *testing.T) {
+	t.Skip("TODO(SNOW-2081651): re-enable this if the test is still relevant without the BCR bundle update as now it's enabled by default in Snowflake")
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)

--- a/pkg/testacc/resource_grant_database_role_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_grant_database_role_account_level_acceptance_test.go
@@ -22,6 +22,7 @@ import (
 
 // proves that https://github.com/snowflakedb/terraform-provider-snowflake/issues/3629 is fixed
 func TestAcc_GrantDatabaseRole_Issue_3629(t *testing.T) {
+	t.Skip("TODO(SNOW-2081651): re-enable this if the test is still relevant without the BCR bundle update as now it's enabled by default in Snowflake")
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	databaseRole, databaseRoleCleanup := secondaryTestClient().DatabaseRole.CreateDatabaseRole(t)

--- a/pkg/testacc/resource_grant_privileges_to_account_role_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_account_role_account_level_acceptance_test.go
@@ -20,6 +20,7 @@ import (
 
 // proves that https://github.com/snowflakedb/terraform-provider-snowflake/issues/3629 (UBAC) doesn't affect the grant privileges to account role resource
 func TestAcc_GrantPrivilegesToAccountRole_OnDatabase_WithPrivilegesGrantedOnDatabaseToUser(t *testing.T) {
+	t.Skip("TODO(SNOW-2081651): re-enable this if the test is still relevant without the BCR bundle update as now it's enabled by default in Snowflake")
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	role, roleCleanup := secondaryTestClient().Role.CreateRole(t)

--- a/pkg/testacc/resource_grant_privileges_to_database_role_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_database_role_account_level_acceptance_test.go
@@ -21,6 +21,7 @@ import (
 
 // proves that https://github.com/snowflakedb/terraform-provider-snowflake/issues/3629 (UBAC) doesn't affect the grant privileges to database role resource
 func TestAcc_GrantPrivilegesToDatabaseRole_OnDatabase_WithPrivilegesGrantedOnDatabaseToUser(t *testing.T) {
+	t.Skip("TODO(SNOW-2081651): re-enable this if the test is still relevant without the BCR bundle update as now it's enabled by default in Snowflake")
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 
 	databaseRole, databaseRoleCleanup := secondaryTestClient().DatabaseRole.CreateDatabaseRole(t)


### PR DESCRIPTION
## Changes
- Change build tag for tests that alter current account as it was making user tests fail with parameter errors
- Skip tests that enable 2025_02 BCR bundle as it's now enabled by default in Snowflake. Added TODO with ticket number to later address those tests.