### PR TITLE
chore: Do not build the whole project after the changelog entry

### DIFF
--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -38,7 +38,6 @@ jobs:
               - 'framework/**'
               - 'tools/**'
               - 'Makefile'
-              - 'CHANGELOG.md'
               - 'main.go'
               - 'go.mod'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
               - 'framework/**'
               - 'tools/**'
               - 'Makefile'
-              - 'CHANGELOG.md'
               - 'main.go'
               - 'go.mod'
 


### PR DESCRIPTION
Remove CHANGELOG.md from run tests filter