### PR TITLE
docs: Fill out the migration guide and the BCR guide for functions and procedures changes

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -29,6 +29,18 @@ We added a new `PROGRAMMATIC_ACCESS_TOKEN` option to the `authenticator` field i
 
 See [Snowflake official documentation](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) for more information on PAT authentication.
 
+### *(bugfix)* Fix `snowflake_functions` and `snowflake_procedures` data sources with 2025_03 Bundle enabled
+
+Check for more details and action steps needed in [Argument output changes for SHOW FUNCTIONS and SHOW PROCEDURES commands](./SNOWFLAKE_BCR_MIGRATION_GUIDE.md#argument-output-changes-for-show-functions-and-show-procedures-commands).
+
+References: [#3822](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3822)
+
+### *(bugfix)* Fix all function and procedure resources with 2025_03 Bundle enabled
+
+Check for more details and action steps needed in [Argument output changes for SHOW FUNCTIONS and SHOW PROCEDURES commands](./SNOWFLAKE_BCR_MIGRATION_GUIDE.md#argument-output-changes-for-show-functions-and-show-procedures-commands).
+
+References: [#3823](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3823)
+
 ## v2.1.0 ➞ v2.2.0
 
 ### *(bugfix)* Fix `ENABLE_INTERNAL_STAGES_PRIVATELINK` mapping in `snowflake_account_parameter` resource

--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -27,9 +27,32 @@ Reference: [BCR-1926](https://docs.snowflake.com/en/release-notes/bcr-bundles/20
 
 ### Argument output changes for SHOW FUNCTIONS and SHOW PROCEDURES commands
 
-(will be filled in soon)
+Changed format in `Arguments` column from `SHOW FUNCTIONS/PROCEDURES` output is not compatible with the provider parsing function. It leads to:
+- [`snowflake_functions`](https://registry.terraform.io/providers/snowflakedb/snowflake/2.2.0/docs/data-sources/functions) and [`snowflake_procedures`](https://registry.terraform.io/providers/snowflakedb/snowflake/2.2.0/docs/data-sources/procedures) being inoperable. Check: [#3822](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3822).
+- All function and all procedure resources failing to read their state from Snowflake, which leads to removing them from terraform state (if `terraform apply` or `terraform plan --refresh-only` is run). Check: [#3823](https://github.com/snowflakedb/terraform-provider-snowflake/issues/3823).
+
+The parsing was improved and is available starting with the [2.3.0](https://registry.terraform.io/providers/snowflakedb/snowflake/2.3.0/docs/) version of the provider.
+
+To use the provider with the 2025_03 Bundle:
+1. Bump the provider to 2.3.0 version.
+2. Affected data sources should work without any further actions after bumping.
+3. If your function/procedure resources were removed from terraform state (you can check it by running `terraform state list`), you need to reimport them (follow our [resource migration guide](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/guides/resource_migration)).
+4. If your function/procedure resources are still in the terraform state, they should work any further actions after bumping.
 
 Reference: [BCR-1944](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03/bcr-1944)
+
+### New maximum size limits for database objects
+
+Max sizes for the few data types were increased.
+
+There are no immediate impacts found on the provider execution.
+However, as explained in the [Data type changes](./MIGRATION_GUIDE.md#data-type-changes) section of our migration guide, the provider fills out the data type attributes (like size) if they are not provided by the user.
+Sizes of `VARCHAR` and `BINARY` data types (when no size is specified) will continue to use the old defaults in the provider (16MB and 8MB respectively).
+If you want to use bigger sizes after enabling the Bundle, please specify them explicitly.
+
+These default values may be changed in the future versions of the provider.
+
+Reference: [BCR-1942](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03/bcr-1942)
 
 ### Python UDFs and stored procedures: Stop implicit auto-injection of the psutil package
 


### PR DESCRIPTION
Describe the migration guide and the BCR migration guide for the updated `SHOW FUNCTIONS/PROCEDURES` behavior after 2025_03 Bundle activation.