### PR TITLE
chore: Address pre-push errors

### DIFF
--- a/pkg/sdk/config_test.go
+++ b/pkg/sdk/config_test.go
@@ -840,7 +840,7 @@ func TestConfigDTODriverConfig(t *testing.T) {
 				assert.Equal(t, 60*time.Second, got.ExternalBrowserTimeout)
 				assert.Equal(t, 2, got.MaxRetryCount)
 				assert.Equal(t, gosnowflake.AuthTypeJwt, got.Authenticator)
-				assert.True(t, got.InsecureMode)
+				assert.True(t, got.InsecureMode) // nolint:staticcheck
 				assert.Equal(t, gosnowflake.OCSPFailOpenTrue, got.OCSPFailOpen)
 				assert.Equal(t, "token", got.Token)
 				assert.True(t, got.KeepSessionAlive)

--- a/pkg/sdk/legacy_config_test.go
+++ b/pkg/sdk/legacy_config_test.go
@@ -434,7 +434,7 @@ func TestLegacyConfigDTODriverConfig(t *testing.T) {
 				assert.Equal(t, 60*time.Second, got.ExternalBrowserTimeout)
 				assert.Equal(t, 2, got.MaxRetryCount)
 				assert.Equal(t, gosnowflake.AuthTypeJwt, got.Authenticator)
-				assert.True(t, got.InsecureMode)
+				assert.True(t, got.InsecureMode) // nolint:staticcheck
 				assert.Equal(t, gosnowflake.OCSPFailOpenTrue, got.OCSPFailOpen)
 				assert.Equal(t, "token", got.Token)
 				assert.True(t, got.KeepSessionAlive)


### PR DESCRIPTION
## Changes
- Disable linter for deprecated InsecureMode assertions