### PR TITLE
chore: Add 2025_04 BCR migration guide

### DIFF
--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -44,10 +44,6 @@ Reference: [BCR-1944](https://docs.snowflake.com/release-notes/bcr-bundles/un-bu
 The `MFA_AUTHENTICATION_METHODS` property is deprecated. Setting the `MFA_AUTHENTICATION_METHODS` property returns an error. If you use the [authentication_policy](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/authentication_policy) resource with `mfa_authentication_methods` field
 and have this bundle enabled, the provider will return an error.
 
-A new `MFA_POLICY` property is available with an `ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION` option, which accepts `ALL` or `NONE` as values.
-Authentication policies with the `MFA_AUTHENTICATION_METHODS` specified return a deprecation message under the DESCRIPTION column in the output of a DESCRIBE AUTHENTICATION POLICY command.
-This will be addressed in the next versions of the provider.
-
 Reference: [BCR-1971](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1971)
 
 ## [Bundle 2025_03](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03_bundle)

--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -32,18 +32,19 @@ To use the provider with the bundles containing this change:
 
 Reference: [BCR-1944](https://docs.snowflake.com/release-notes/bcr-bundles/un-bundled/bcr-1944)
 
-## [Bundle 2025_04](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04_bundle)
-
-### Primary role requires stage access during `CREATE EXTERNAL TABLE` command
-
-Creating an external table succeeds only if a user’s primary role has the `USAGE` privilege on the stage referenced in the `snowflake_external_table` resource. If you manage external tables in the provider, please grant the `USAGE` privilege on the relevant stages to the connection role.
-
-Reference: [BCR-1993](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1993)
-
 ### `MFA_AUTHENTICATION_METHODS` property in authentication policies is now deprecated
 <!-- TODO(SNOW-2187814): Update this entry. -->
 
-The `MFA_AUTHENTICATION_METHODS` property is deprecated. A new `MFA_POLICY` property is available with an `ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION` option, which accepts `ALL` or `NONE` as values.
+> [!IMPORTANT]
+> This change has been rolled back from the BCR 2025_04.
+
+> [!IMPORTANT]
+> This change has not been addressed in the provider yet. This will be addressed in the next versions of the provider.
+
+The `MFA_AUTHENTICATION_METHODS` property is deprecated. Setting the `MFA_AUTHENTICATION_METHODS` property returns an error. If you use the [authentication_policy](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/resources/authentication_policy) resource with `mfa_authentication_methods` field
+and have this bundle enabled, the provider will return an error.
+
+A new `MFA_POLICY` property is available with an `ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION` option, which accepts `ALL` or `NONE` as values.
 Authentication policies with the `MFA_AUTHENTICATION_METHODS` specified return a deprecation message under the DESCRIPTION column in the output of a DESCRIBE AUTHENTICATION POLICY command.
 This will be addressed in the next versions of the provider.
 

--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -32,6 +32,23 @@ To use the provider with the bundles containing this change:
 
 Reference: [BCR-1944](https://docs.snowflake.com/release-notes/bcr-bundles/un-bundled/bcr-1944)
 
+## [Bundle 2025_04](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04_bundle)
+
+### Primary role requires stage access during `CREATE EXTERNAL TABLE` command
+
+Creating an external table succeeds only if a user’s primary role has the `USAGE` privilege on the stage referenced in the `snowflake_external_table` resource. If you manage external tables in the provider, please grant the `USAGE` privilege on the relevant stages to the connection role.
+
+Reference: [BCR-1993](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1993)
+
+### `MFA_AUTHENTICATION_METHODS` property in authentication policies is now deprecated
+<!-- TODO(SNOW-2187814): Update this entry. -->
+
+The `MFA_AUTHENTICATION_METHODS` property is deprecated. A new `MFA_POLICY` property is available with an `ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION` option, which accepts `ALL` or `NONE` as values.
+Authentication policies with the `MFA_AUTHENTICATION_METHODS` specified return a deprecation message under the DESCRIPTION column in the output of a DESCRIBE AUTHENTICATION POLICY command.
+This will be addressed in the next versions of the provider.
+
+Reference: [BCR-1971](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1971)
+
 ## [Bundle 2025_03](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03_bundle)
 
 ### The `CREATE DATA EXCHANGE LISTING` privilege rename

--- a/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
+++ b/SNOWFLAKE_BCR_MIGRATION_GUIDE.md
@@ -46,6 +46,14 @@ and have this bundle enabled, the provider will return an error.
 
 Reference: [BCR-1971](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1971)
 
+## [Bundle 2025_04](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04_bundle)
+
+### Primary role requires stage access during `CREATE EXTERNAL TABLE` command
+
+Creating an external table succeeds only if a user’s primary role has the `USAGE` privilege on the stage referenced in the `snowflake_external_table` resource. If you manage external tables in the provider, please grant the `USAGE` privilege on the relevant stages to the connection role.
+
+Reference: [BCR-1993](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04/bcr-1993)
+
 ## [Bundle 2025_03](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_03_bundle)
 
 ### The `CREATE DATA EXCHANGE LISTING` privilege rename


### PR DESCRIPTION
Add Snowflake BCR 2025_04 migration guide:
- Add an entry for altered privileges check in Snowflake.
- Add an entry for changes in authentication methods.


## References
* [Snowflake BCR Bundle 2025_04](https://docs.snowflake.com/en/release-notes/bcr-bundles/2025_04_bundle)