### PR TITLE
fix: permadiff when granting privileges to shares on non-standard tables

### DIFF
--- a/pkg/resources/grant_privileges_to_share.go
+++ b/pkg/resources/grant_privileges_to_share.go
@@ -580,13 +580,18 @@ func prepareShowGrantsRequestForShare(id GrantPrivilegesToShareId) (*sdk.ShowGra
 // This handles cases where GrantedOn (from `SHOW GRANTS`) might be a different type variant
 // from the same base type, e.g. `EXTERNAL_TABLE` vs `TABLE`, `DYNAMIC_TABLE` vs `TABLE`, etc.
 func isGrantedOnEquivalent(expected, actual sdk.ObjectType) bool {
-	// If they're exactly the same, no need for normalization
 	if expected == actual {
 		return true
 	}
+    // If expected is TABLE, we consider it equivalent to any table-like type
 	if expected == sdk.ObjectTypeTable {
-		// If expected is TABLE, we consider it equivalent to any table-like type
-		return actual == sdk.ObjectTypeExternalTable || actual == sdk.ObjectTypeDynamicTable || actual == sdk.ObjectTypeIcebergTable
+		tableTypes := []sdk.ObjectType{
+			sdk.ObjectTypeExternalTable,
+			sdk.ObjectTypeDynamicTable,
+			sdk.ObjectTypeIcebergTable,
+			sdk.ObjectTypeHybridTable,
+		}
+		return slices.Contains(tableTypes, actual)
 	}
 	return false
 }

--- a/pkg/resources/grant_privileges_to_share.go
+++ b/pkg/resources/grant_privileges_to_share.go
@@ -583,7 +583,7 @@ func isGrantedOnEquivalent(expected, actual sdk.ObjectType) bool {
 	if expected == actual {
 		return true
 	}
-    // If expected is TABLE, we consider it equivalent to any table-like type
+	// If expected is TABLE, we consider it equivalent to any table-like type
 	if expected == sdk.ObjectTypeTable {
 		tableTypes := []sdk.ObjectType{
 			sdk.ObjectTypeExternalTable,

--- a/pkg/resources/grant_privileges_to_share_identifier_test.go
+++ b/pkg/resources/grant_privileges_to_share_identifier_test.go
@@ -226,3 +226,63 @@ func TestGrantPrivilegesToShareIdString(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGrantedOnEquivalent(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Expected sdk.ObjectType
+		Actual   sdk.ObjectType
+		Result   bool
+	}{
+		{
+			Name:     "identical types",
+			Expected: sdk.ObjectTypeTable,
+			Actual:   sdk.ObjectTypeTable,
+			Result:   true,
+		},
+		{
+			Name:     "table vs external table",
+			Expected: sdk.ObjectTypeTable,
+			Actual:   sdk.ObjectTypeExternalTable,
+			Result:   true,
+		},
+		{
+			Name:     "table vs dynamic table",
+			Expected: sdk.ObjectTypeTable,
+			Actual:   sdk.ObjectTypeDynamicTable,
+			Result:   true,
+		},
+		{
+			Name:     "table vs iceberg table",
+			Expected: sdk.ObjectTypeTable,
+			Actual:   sdk.ObjectTypeIcebergTable,
+			Result:   true,
+		},
+		{
+			Name:     "external table vs table - not equivalent (expected is not TABLE)",
+			Expected: sdk.ObjectTypeExternalTable,
+			Actual:   sdk.ObjectTypeTable,
+			Result:   false,
+		},
+		{
+			Name:     "different base types",
+			Expected: sdk.ObjectTypeTable,
+			Actual:   sdk.ObjectTypeView,
+			Result:   false,
+		},
+		{
+			Name:     "view vs table",
+			Expected: sdk.ObjectTypeView,
+			Actual:   sdk.ObjectTypeTable,
+			Result:   false,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			result := isGrantedOnEquivalent(tt.Expected, tt.Actual)
+			assert.Equal(t, tt.Result, result)
+		})
+	}
+}

--- a/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
@@ -180,6 +180,67 @@ func TestAcc_GrantPrivilegesToShare_OnTable(t *testing.T) {
 	})
 }
 
+func TestAcc_GrantPrivilegesToShare_OnDynamicTable(t *testing.T) {
+	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
+	t.Cleanup(databaseCleanup)
+
+	schema, schemaCleanup := testClient().Schema.CreateSchemaInDatabase(t, database.ID())
+	t.Cleanup(schemaCleanup)
+
+	share, shareCleanup := testClient().Share.CreateShare(t)
+	t.Cleanup(shareCleanup)
+
+	dynamicTableId := testClient().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID())
+
+	configVariables := config.Variables{
+		"to_share": config.StringVariable(share.ID().Name()),
+		"database": config.StringVariable(database.ID().Name()),
+		"schema":   config.StringVariable(schema.ID().Name()),
+		"warehouse":  config.StringVariable(TestWarehouseName),
+		"on_table": config.StringVariable(dynamicTableId.Name()),
+		"privileges": config.ListVariable(
+			config.StringVariable(sdk.ObjectPrivilegeSelect.String()),
+		),
+	}
+
+	resourceName := "snowflake_grant_privileges_to_share.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+		PreCheck:                 func() { TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToShare/OnDynamicTable"),
+				ConfigVariables: configVariables,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "to_share", share.ID().Name()),
+					resource.TestCheckResourceAttr(resourceName, "privileges.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0", sdk.ObjectPrivilegeSelect.String()),
+					resource.TestCheckResourceAttr(resourceName, "on_table", dynamicTableId.FullyQualifiedName()),
+				),
+			},
+			{
+				ConfigDirectory:   ConfigurationDirectory("TestAcc_GrantPrivilegesToShare/OnDynamicTable"),
+				ConfigVariables:   configVariables,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ConfigDirectory: ConfigurationDirectory("TestAcc_GrantPrivilegesToShare/OnDynamicTable"),
+				ConfigVariables: configVariables,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAcc_GrantPrivilegesToShare_OnAllTablesInSchema(t *testing.T) {
 	database, databaseCleanup := testClient().Database.CreateDatabaseWithParametersSet(t)
 	t.Cleanup(databaseCleanup)

--- a/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
+++ b/pkg/testacc/resource_grant_privileges_to_share_acceptance_test.go
@@ -193,11 +193,11 @@ func TestAcc_GrantPrivilegesToShare_OnDynamicTable(t *testing.T) {
 	dynamicTableId := testClient().Ids.RandomSchemaObjectIdentifierInSchema(schema.ID())
 
 	configVariables := config.Variables{
-		"to_share": config.StringVariable(share.ID().Name()),
-		"database": config.StringVariable(database.ID().Name()),
-		"schema":   config.StringVariable(schema.ID().Name()),
-		"warehouse":  config.StringVariable(TestWarehouseName),
-		"on_table": config.StringVariable(dynamicTableId.Name()),
+		"to_share":  config.StringVariable(share.ID().Name()),
+		"database":  config.StringVariable(database.ID().Name()),
+		"schema":    config.StringVariable(schema.ID().Name()),
+		"warehouse": config.StringVariable(TestWarehouseName),
+		"on_table":  config.StringVariable(dynamicTableId.Name()),
 		"privileges": config.ListVariable(
 			config.StringVariable(sdk.ObjectPrivilegeSelect.String()),
 		),

--- a/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/test.tf
+++ b/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/test.tf
@@ -10,14 +10,14 @@ resource "snowflake_table" "base_table" {
 }
 
 resource "snowflake_dynamic_table" "test_dynamic_table" {
-  name       = var.on_table
-  database   = var.database
-  schema     = var.schema
+  name     = var.on_table
+  database = var.database
+  schema   = var.schema
   target_lag {
     maximum_duration = "2 minutes"
   }
   warehouse = var.warehouse
-  query = <<-EOT
+  query     = <<-EOT
     with temp as (
       select "id" from ${snowflake_table.base_table.fully_qualified_name}
     )

--- a/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/test.tf
+++ b/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/test.tf
@@ -1,0 +1,39 @@
+resource "snowflake_table" "base_table" {
+  database        = var.database
+  schema          = var.schema
+  name            = "${var.on_table}_base"
+  change_tracking = true
+  column {
+    name = "id"
+    type = "NUMBER(38,0)"
+  }
+}
+
+resource "snowflake_dynamic_table" "test_dynamic_table" {
+  name       = var.on_table
+  database   = var.database
+  schema     = var.schema
+  target_lag {
+    maximum_duration = "2 minutes"
+  }
+  warehouse = var.warehouse
+  query = <<-EOT
+    with temp as (
+      select "id" from ${snowflake_table.base_table.fully_qualified_name}
+    )
+    select * from temp
+  EOT
+}
+
+resource "snowflake_grant_privileges_to_share" "test_setup" {
+  to_share    = var.to_share
+  privileges  = ["USAGE"]
+  on_database = var.database
+}
+
+resource "snowflake_grant_privileges_to_share" "test" {
+  to_share   = var.to_share
+  privileges = var.privileges
+  on_table   = snowflake_dynamic_table.test_dynamic_table.fully_qualified_name
+  depends_on = [snowflake_grant_privileges_to_share.test_setup]
+}

--- a/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/variables.tf
+++ b/pkg/testacc/testdata/TestAcc_GrantPrivilegesToShare/OnDynamicTable/variables.tf
@@ -1,0 +1,23 @@
+variable "to_share" {
+  type = string
+}
+
+variable "privileges" {
+  type = list(string)
+}
+
+variable "database" {
+  type = string
+}
+
+variable "schema" {
+  type = string
+}
+
+variable "on_table" {
+  type = string
+}
+
+variable "warehouse" {
+  type = string
+}


### PR DESCRIPTION
Solves #3167 

Fix permadiff when granting privileges to shares on external, dynamic, hybrid, and iceberg tables

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [x] acceptance tests
<!-- add more below if you think they are relevant -->
* [x] unit tests

## References
<!-- issues documentation links, etc  -->

* 