### PR TITLE
chore: Checkout to the commit SHA from the slash command

### DIFF
--- a/.github/workflows/tests-account-level.yml
+++ b/.github/workflows/tests-account-level.yml
@@ -65,7 +65,7 @@ jobs:
         if: (github.event_name == 'repository_dispatch')
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
           persist-credentials: false
 
       - name: Checkout Code (Pull Request Event)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         if: (github.event_name == 'repository_dispatch')
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+          ref: ${{ github.event.client_payload.slash_command.args.named.sha }}
           persist-credentials: false
 
       - name: Checkout Code (Pull Request Event)


### PR DESCRIPTION
When running the repository_dispatch, checkout to the commit SHA from the slash command.