### PR TITLE
fix: Fix secondary connection read

### DIFF
--- a/pkg/resources/secondary_connection.go
+++ b/pkg/resources/secondary_connection.go
@@ -145,7 +145,7 @@ func ReadContextSecondaryConnection(ctx context.Context, d *schema.ResourceData,
 		d.Set(FullyQualifiedNameAttributeName, id.FullyQualifiedName()),
 		d.Set(ShowOutputAttributeName, []map[string]any{schemas.ConnectionToSchema(connection)}),
 		d.Set("comment", connection.Comment),
-		d.Set("as_replica_of", connection.Primary),
+		d.Set("as_replica_of", connection.Primary.FullyQualifiedName()),
 	))
 }
 


### PR DESCRIPTION
Save a fully qualified name string in the `as_replica_of` field