### PR TITLE
fix: Change convert signature for a single object

### DIFF
--- a/pkg/sdk/database_role.go
+++ b/pkg/sdk/database_role.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 )
 
-var _ convertibleRow[DatabaseRole] = new(databaseRoleDBRow)
+var _ convertibleRowDeprecated[DatabaseRole] = new(databaseRoleDBRow)
 
 type DatabaseRoles interface {
 	Create(ctx context.Context, request *CreateDatabaseRoleRequest) error

--- a/pkg/sdk/external_tables.go
+++ b/pkg/sdk/external_tables.go
@@ -7,9 +7,9 @@ import (
 )
 
 var (
-	_ convertibleRow[ExternalTable]              = (*externalTableRow)(nil)
-	_ convertibleRow[ExternalTableColumnDetails] = (*externalTableColumnDetailsRow)(nil)
-	_ convertibleRow[ExternalTableStageDetails]  = (*externalTableStageDetailsRow)(nil)
+	_ convertibleRowDeprecated[ExternalTable]              = (*externalTableRow)(nil)
+	_ convertibleRowDeprecated[ExternalTableColumnDetails] = (*externalTableColumnDetailsRow)(nil)
+	_ convertibleRowDeprecated[ExternalTableStageDetails]  = (*externalTableStageDetailsRow)(nil)
 )
 
 type ExternalTables interface {

--- a/pkg/sdk/grants.go
+++ b/pkg/sdk/grants.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var _ convertibleRow[Grant] = new(grantRow)
+var _ convertibleRowDeprecated[Grant] = new(grantRow)
 
 type Grants interface {
 	GrantPrivilegesToAccountRole(ctx context.Context, privileges *AccountRoleGrantPrivileges, on *AccountRoleGrantOn, role AccountObjectIdentifier, opts *GrantPrivilegesToAccountRoleOptions) error

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -80,7 +80,7 @@ func convertRows[T convertibleRowDeprecated[U], U any](dbRows []T) []U {
 }
 
 type convertibleRow[T any] interface {
-	// TODO [SNOW-2259477]: rename to convertErr
+	// TODO [SNOW-2259477]: rename to convert
 	convertErr() (*T, error)
 }
 

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -66,11 +66,11 @@ func createIfNil[T any](t *T) *T {
 	return t
 }
 
-type convertibleRow[T any] interface {
+type convertibleRowDeprecated[T any] interface {
 	convert() *T
 }
 
-func convertRows[T convertibleRow[U], U any](dbRows []T) []U {
+func convertRows[T convertibleRowDeprecated[U], U any](dbRows []T) []U {
 	resultList := make([]U, len(dbRows))
 	for i, row := range dbRows {
 		resultList[i] = *(row.convert())

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -78,6 +78,22 @@ func convertRows[T convertibleRowDeprecated[U], U any](dbRows []T) []U {
 	return resultList
 }
 
+type convertibleRow[T any] interface {
+	convertErr() (*T, error)
+}
+
+func convertRowsErr[T convertibleRow[U], U any](dbRows []T) ([]U, error) {
+	resultList := make([]U, len(dbRows))
+	for i, row := range dbRows {
+		converted, err := row.convertErr()
+		if err != nil {
+			return nil, err
+		}
+		resultList[i] = *converted
+	}
+	return resultList, nil
+}
+
 type optionsProvider[T any] interface {
 	toOpts() *T
 }

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -80,9 +80,11 @@ func convertRows[T convertibleRowDeprecated[U], U any](dbRows []T) []U {
 }
 
 type convertibleRow[T any] interface {
+	// TODO [SNOW-2259477]: rename to convertErr
 	convertErr() (*T, error)
 }
 
+// TODO [SNOW-2259477]: rename to convertRows
 func convertRowsErr[T convertibleRow[U], U any](dbRows []T) ([]U, error) {
 	resultList := make([]U, len(dbRows))
 	for i, row := range dbRows {

--- a/pkg/sdk/helpers_proposal.go
+++ b/pkg/sdk/helpers_proposal.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"context"
+	"fmt"
 )
 
 // validatable is our sdk interface for anything that can be validated (e.g. CreateXxxOptions).
@@ -85,13 +86,21 @@ type convertibleRow[T any] interface {
 func convertRowsErr[T convertibleRow[U], U any](dbRows []T) ([]U, error) {
 	resultList := make([]U, len(dbRows))
 	for i, row := range dbRows {
-		converted, err := row.convertErr()
+		converted, err := conversionErrorWrapped(row.convertErr())
 		if err != nil {
 			return nil, err
 		}
 		resultList[i] = *converted
 	}
 	return resultList, nil
+}
+
+func conversionErrorWrapped[U any](converted *U, err error) (*U, error) {
+	if err != nil {
+		return nil, fmt.Errorf("conversion from Snowflake failed with error: %w", err)
+	} else {
+		return converted, nil
+	}
 }
 
 type optionsProvider[T any] interface {

--- a/pkg/sdk/pipes.go
+++ b/pkg/sdk/pipes.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 )
 
-var _ convertibleRow[Pipe] = new(pipeDBRow)
+var _ convertibleRowDeprecated[Pipe] = new(pipeDBRow)
 
 type Pipes interface {
 	Create(ctx context.Context, id SchemaObjectIdentifier, copyStatement string, opts *CreatePipeOptions) error

--- a/pkg/sdk/policy_references.go
+++ b/pkg/sdk/policy_references.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var _ convertibleRow[PolicyReference] = new(policyReferenceDBRow)
+var _ convertibleRowDeprecated[PolicyReference] = new(policyReferenceDBRow)
 
 type PolicyReferences interface {
 	GetForEntity(ctx context.Context, request *GetForEntityPolicyReferenceRequest) ([]PolicyReference, error)

--- a/pkg/sdk/replication_functions.go
+++ b/pkg/sdk/replication_functions.go
@@ -15,7 +15,7 @@ var (
 	_ validatable = new(ShowReplicationDatabasesOptions)
 )
 
-var _ convertibleRow[ReplicationDatabase] = new(replicationDatabaseRow)
+var _ convertibleRowDeprecated[ReplicationDatabase] = new(replicationDatabaseRow)
 
 type ReplicationFunctions interface {
 	ShowReplicationAccounts(ctx context.Context) ([]*ReplicationAccount, error)

--- a/pkg/sdk/roles_impl.go
+++ b/pkg/sdk/roles_impl.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	_ Roles                = (*roles)(nil)
-	_ convertibleRow[Role] = (*roleDBRow)(nil)
+	_ Roles                          = (*roles)(nil)
+	_ convertibleRowDeprecated[Role] = (*roleDBRow)(nil)
 )
 
 type roles struct {

--- a/pkg/sdk/tables.go
+++ b/pkg/sdk/tables.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-var _ convertibleRow[Table] = new(tableDBRow)
+var _ convertibleRowDeprecated[Table] = new(tableDBRow)
 
 // TODO [SNOW-1007542]: add missing features:
 // - show columns (https://docs.snowflake.com/en/sql-reference/sql/show-columns)

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -531,25 +531,33 @@ func (row warehouseDBRow) convertErr() (*Warehouse, error) {
 	} else {
 		wh.Size = size
 	}
-	if val, err := strconv.ParseFloat(row.Available, 64); err != nil {
-		return nil, err
-	} else {
-		wh.Available = val
+	if available := strings.TrimSpace(row.Available); available != "" {
+		if val, err := strconv.ParseFloat(available, 64); err != nil {
+			return nil, fmt.Errorf(`row "available" has incorrect value %s, %w`, available, err)
+		} else {
+			wh.Available = val
+		}
 	}
-	if val, err := strconv.ParseFloat(row.Provisioning, 64); err != nil {
-		return nil, err
-	} else {
-		wh.Provisioning = val
+	if provisioning := strings.TrimSpace(row.Provisioning); provisioning != "" {
+		if val, err := strconv.ParseFloat(provisioning, 64); err != nil {
+			return nil, fmt.Errorf(`row "provisioning" has incorrect value %s, %w`, provisioning, err)
+		} else {
+			wh.Provisioning = val
+		}
 	}
-	if val, err := strconv.ParseFloat(row.Quiescing, 64); err != nil {
-		return nil, err
-	} else {
-		wh.Quiescing = val
+	if quiescing := strings.TrimSpace(row.Available); quiescing != "" {
+		if val, err := strconv.ParseFloat(quiescing, 64); err != nil {
+			return nil, fmt.Errorf(`row "quiescing" has incorrect value %s, %w`, quiescing, err)
+		} else {
+			wh.Quiescing = val
+		}
 	}
-	if val, err := strconv.ParseFloat(row.Other, 64); err != nil {
-		return nil, err
-	} else {
-		wh.Other = val
+	if other := strings.TrimSpace(row.Available); other != "" {
+		if val, err := strconv.ParseFloat(other, 64); err != nil {
+			return nil, fmt.Errorf(`row "other" has incorrect value %s, %w`, other, err)
+		} else {
+			wh.Other = val
+		}
 	}
 	if row.AutoSuspend.Valid {
 		wh.AutoSuspend = int(row.AutoSuspend.Int64)

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -553,6 +553,65 @@ func (row warehouseDBRow) convert() *Warehouse {
 	return wh
 }
 
+func (row warehouseDBRow) convertErr() (*Warehouse, error) {
+	wh := &Warehouse{
+		Name:                            row.Name,
+		State:                           WarehouseState(row.State),
+		Type:                            WarehouseType(row.Type),
+		MinClusterCount:                 row.MinClusterCount,
+		MaxClusterCount:                 row.MaxClusterCount,
+		StartedClusters:                 row.StartedClusters,
+		Running:                         row.Running,
+		Queued:                          row.Queued,
+		IsDefault:                       row.IsDefault == "Y",
+		IsCurrent:                       row.IsCurrent == "Y",
+		AutoResume:                      row.AutoResume,
+		CreatedOn:                       row.CreatedOn,
+		ResumedOn:                       row.ResumedOn,
+		UpdatedOn:                       row.UpdatedOn,
+		Owner:                           row.Owner,
+		Comment:                         row.Comment,
+		EnableQueryAcceleration:         row.EnableQueryAcceleration,
+		QueryAccelerationMaxScaleFactor: row.QueryAccelerationMaxScaleFactor,
+		ScalingPolicy:                   ScalingPolicy(row.ScalingPolicy),
+	}
+	if size, err := ToWarehouseSize(row.Size); err != nil {
+		return nil, err
+	} else {
+		wh.Size = size
+	}
+	if val, err := strconv.ParseFloat(row.Available, 64); err != nil {
+		return nil, err
+	} else {
+		wh.Available = val
+	}
+	if val, err := strconv.ParseFloat(row.Provisioning, 64); err != nil {
+		return nil, err
+	} else {
+		wh.Provisioning = val
+	}
+	if val, err := strconv.ParseFloat(row.Quiescing, 64); err != nil {
+		return nil, err
+	} else {
+		wh.Quiescing = val
+	}
+	if val, err := strconv.ParseFloat(row.Other, 64); err != nil {
+		return nil, err
+	} else {
+		wh.Other = val
+	}
+	if row.AutoSuspend.Valid {
+		wh.AutoSuspend = int(row.AutoSuspend.Int64)
+	}
+	if row.OwnerRoleType.Valid {
+		wh.OwnerRoleType = row.OwnerRoleType.String
+	}
+	if row.ResourceMonitor != "null" {
+		wh.ResourceMonitor = NewAccountObjectIdentifierFromFullyQualifiedName(row.ResourceMonitor)
+	}
+	return wh, nil
+}
+
 func (c *warehouses) Show(ctx context.Context, opts *ShowWarehouseOptions) ([]Warehouse, error) {
 	opts = createIfNil(opts)
 	dbRows, err := validateAndQuery[warehouseDBRow](c.client, ctx, opts)

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -618,8 +618,8 @@ func (c *warehouses) Show(ctx context.Context, opts *ShowWarehouseOptions) ([]Wa
 	if err != nil {
 		return nil, err
 	}
-	resultList := convertRows[warehouseDBRow, Warehouse](dbRows)
-	return resultList, nil
+	resultList, err := convertRowsErr[warehouseDBRow, Warehouse](dbRows)
+	return resultList, err
 }
 
 func (c *warehouses) ShowByID(ctx context.Context, id AccountObjectIdentifier) (*Warehouse, error) {

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -545,14 +545,14 @@ func (row warehouseDBRow) convertErr() (*Warehouse, error) {
 			wh.Provisioning = val
 		}
 	}
-	if quiescing := strings.TrimSpace(row.Available); quiescing != "" {
+	if quiescing := strings.TrimSpace(row.Quiescing); quiescing != "" {
 		if val, err := strconv.ParseFloat(quiescing, 64); err != nil {
 			return nil, fmt.Errorf(`row 'quiescing' has incorrect value '%s', %w`, quiescing, err)
 		} else {
 			wh.Quiescing = val
 		}
 	}
-	if other := strings.TrimSpace(row.Available); other != "" {
+	if other := strings.TrimSpace(row.Other); other != "" {
 		if val, err := strconv.ParseFloat(other, 64); err != nil {
 			return nil, fmt.Errorf(`row 'other' has incorrect value '%s', %w`, other, err)
 		} else {

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -577,8 +577,7 @@ func (c *warehouses) Show(ctx context.Context, opts *ShowWarehouseOptions) ([]Wa
 	if err != nil {
 		return nil, err
 	}
-	resultList, err := convertRowsErr[warehouseDBRow, Warehouse](dbRows)
-	return resultList, err
+	return convertRowsErr[warehouseDBRow, Warehouse](dbRows)
 }
 
 func (c *warehouses) ShowByID(ctx context.Context, id AccountObjectIdentifier) (*Warehouse, error) {

--- a/pkg/sdk/warehouses.go
+++ b/pkg/sdk/warehouses.go
@@ -533,28 +533,28 @@ func (row warehouseDBRow) convertErr() (*Warehouse, error) {
 	}
 	if available := strings.TrimSpace(row.Available); available != "" {
 		if val, err := strconv.ParseFloat(available, 64); err != nil {
-			return nil, fmt.Errorf(`row "available" has incorrect value %s, %w`, available, err)
+			return nil, fmt.Errorf(`row 'available' has incorrect value '%s', %w`, available, err)
 		} else {
 			wh.Available = val
 		}
 	}
 	if provisioning := strings.TrimSpace(row.Provisioning); provisioning != "" {
 		if val, err := strconv.ParseFloat(provisioning, 64); err != nil {
-			return nil, fmt.Errorf(`row "provisioning" has incorrect value %s, %w`, provisioning, err)
+			return nil, fmt.Errorf(`row 'provisioning' has incorrect value '%s', %w`, provisioning, err)
 		} else {
 			wh.Provisioning = val
 		}
 	}
 	if quiescing := strings.TrimSpace(row.Available); quiescing != "" {
 		if val, err := strconv.ParseFloat(quiescing, 64); err != nil {
-			return nil, fmt.Errorf(`row "quiescing" has incorrect value %s, %w`, quiescing, err)
+			return nil, fmt.Errorf(`row 'quiescing' has incorrect value '%s', %w`, quiescing, err)
 		} else {
 			wh.Quiescing = val
 		}
 	}
 	if other := strings.TrimSpace(row.Available); other != "" {
 		if val, err := strconv.ParseFloat(other, 64); err != nil {
-			return nil, fmt.Errorf(`row "other" has incorrect value %s, %w`, other, err)
+			return nil, fmt.Errorf(`row 'other' has incorrect value '%s', %w`, other, err)
 		} else {
 			wh.Other = val
 		}

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -2,9 +2,10 @@ package sdk
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -450,7 +451,7 @@ func Test_Warehouse_Convert(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, wh)
 		assert.Equal(t, WarehouseSizeXSmall, wh.Size)
-		assert.Equal(t, 100.0, wh.Available)
+		assert.InDelta(t, 100.0, wh.Available, testvars.FloatEpsilon)
 	})
 
 	t.Run("convert correct: available empty", func(t *testing.T) {
@@ -461,6 +462,6 @@ func Test_Warehouse_Convert(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, wh)
-		assert.Equal(t, 0.0, wh.Available)
+		assert.InDelta(t, 0.0, wh.Available, testvars.FloatEpsilon)
 	})
 }

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -412,3 +412,50 @@ func Test_Warehouse_ToScalingPolicy(t *testing.T) {
 		})
 	}
 }
+
+func Test_Warehouse_Convert(t *testing.T) {
+	correctRow := func() warehouseDBRow {
+		return warehouseDBRow{
+			Size: string(WarehouseSizeXSmall),
+		}
+	}
+
+	t.Run("convert error: size invalid", func(t *testing.T) {
+		row := correctRow()
+		row.Size = "INCORRECT_SIZE"
+
+		wh, err := row.convertErr()
+
+		require.Error(t, err)
+		require.Nil(t, wh)
+	})
+
+	t.Run("convert error: available NaN", func(t *testing.T) {
+		row := correctRow()
+		row.Available = "not a number"
+
+		wh, err := row.convertErr()
+
+		require.Error(t, err)
+		require.Nil(t, wh)
+	})
+
+	t.Run("convert correct", func(t *testing.T) {
+		row := correctRow()
+
+		wh, err := row.convertErr()
+
+		require.NoError(t, err)
+		require.NotNil(t, wh)
+	})
+
+	t.Run("convert correct: available empty", func(t *testing.T) {
+		row := correctRow()
+		row.Available = " "
+
+		wh, err := row.convertErr()
+
+		require.NoError(t, err)
+		require.NotNil(t, wh)
+	})
+}

--- a/pkg/sdk/warehouses_test.go
+++ b/pkg/sdk/warehouses_test.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -416,7 +417,8 @@ func Test_Warehouse_ToScalingPolicy(t *testing.T) {
 func Test_Warehouse_Convert(t *testing.T) {
 	correctRow := func() warehouseDBRow {
 		return warehouseDBRow{
-			Size: string(WarehouseSizeXSmall),
+			Size:      string(WarehouseSizeXSmall),
+			Available: "100",
 		}
 	}
 
@@ -426,7 +428,7 @@ func Test_Warehouse_Convert(t *testing.T) {
 
 		wh, err := row.convertErr()
 
-		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid warehouse size: INCORRECT_SIZE")
 		require.Nil(t, wh)
 	})
 
@@ -436,7 +438,7 @@ func Test_Warehouse_Convert(t *testing.T) {
 
 		wh, err := row.convertErr()
 
-		require.Error(t, err)
+		require.ErrorContains(t, err, "row 'available' has incorrect value 'not a number'")
 		require.Nil(t, wh)
 	})
 
@@ -447,6 +449,8 @@ func Test_Warehouse_Convert(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, wh)
+		assert.Equal(t, WarehouseSizeXSmall, wh.Size)
+		assert.Equal(t, 100.0, wh.Available)
 	})
 
 	t.Run("convert correct: available empty", func(t *testing.T) {
@@ -457,5 +461,6 @@ func Test_Warehouse_Convert(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, wh)
+		assert.Equal(t, 0.0, wh.Available)
 	})
 }


### PR DESCRIPTION
It's the first PR of a few aiming to improve SDK's stability and reliability by including an error in the return from conversion attempt. Till now, the errors there were only logged which caused unexpected behavior in some cases (like improper id parsing for functions and , because of that, not finding the function with an empty id).

The change contains:
- Rename `convertibleRow` to `convertibleRowDeprecated`
- Introduce `conversionErrorWrapped` method (it's needed as `convert` is either used from `convertRows` or directly)
- Alter the conversion for warehouse
- Add unit tests for warehouse conversion

Next PRs:
- Migrate all other objects that are not generated from defs
- Alter generation
- Migrate all other objects that are generated
- Rename `convertRowsErr` to `convertRows` when all objects are migrated
- Rename `convertErr` to `convert` when all objects are migrated
- Remove `convertibleRowDeprecated` when all objects are migrated

Future improvements:
- Add compile checks like `var _ convertibleRowDeprecated[DatabaseRole] = new(databaseRoleDBRow)` for each convertible (generate it)

Questions:
- Do we want to have extensive unit tests for each conversion?
- Do we want to generate these tests?