### PR TITLE
fix: Connection fixes follow-up

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -24,6 +24,20 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 > [!TIP]
 > If you're still using the `Snowflake-Labs/snowflake` source, see [Upgrading from Snowflake-Labs Provider](./SNOWFLAKEDB_MIGRATION.md) to upgrade to the snowflakedb namespace.
 
+## v2.5.0 ➞ v2.5.1
+
+### *(bugfix)* Fixed `snowflake_primary_connection` or `snowflake_secondary_connection` reading and improved creation and deletion operations
+
+When configuring `snowflake_primary_connection` or `snowflake_secondary_connection` resources, previous issues could lead to failures or incorrect planning.
+These problems arose because the shared connections appear in the `SHOW CONNECTIONS` command, and if a primary and secondary connection had the same name,
+they were not distinguished correctly; the first appearing one was chosen. We have now resolved this by fixing the function that retrieves the connection by ID, ensuring such issues do not occur.
+
+Additionally, we have made adjustments to the create operation for `snowflake_secondary_connection` and the delete operations for both `snowflake_primary_connection` and `snowflake_secondary_connection`.
+These adjustments aim to prevent issues that could arise from Snowflake systems registering or unregistering connections asynchronously to the create/delete operations.
+However, these issues may still occur depending on system latencies. If you encounter errors from the provider when creating or deleting both in the same `terraform apply`, please report them.
+
+We generally recommend splitting the creation and deletion of both resources into two steps to allow Snowflake's background systems sufficient time to process these operations efficiently.
+
 ## v2.4.x ➞ v2.5.0
 
 ### *(bugfix)* Fixed incorrect authenticator when using the `token` field

--- a/docs/resources/secondary_connection.md
+++ b/docs/resources/secondary_connection.md
@@ -28,7 +28,7 @@ resource "snowflake_secondary_connection" "complete" {
 
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).
 
--> **Note** Creating secondary connections with `snowflake_primary_connection` should be done in two steps (terraform applies): first create the primary connection, then create the secondary connection. Snowflake needs some time to register the primary connection before you can create secondary connections based on it.
+-> **Note** Creating secondary connections with `snowflake_primary_connection` may fail and should be done in two steps (terraform applies): first create the primary connection, then create the secondary connection. Snowflake needs some time to register the primary connection before you can create secondary connections based on it. The provider is handling it internally with a retry mechanism, but the time to register may differ and be longer than retry's maximum wait time.
 
 -> **Note** To promote `snowflake_secondary_connection` to [`snowflake_primary_connection`](./primary_connection), resources need to be migrated manually. For guidance on removing and importing resources into the state check [resource migration](../guides/resource_migration). Remove the resource from the state with [terraform state rm](https://developer.hashicorp.com/terraform/cli/commands/state/rm), then promote it manually using:
     ```

--- a/pkg/acceptance/helpers/connection_client.go
+++ b/pkg/acceptance/helpers/connection_client.go
@@ -81,7 +81,7 @@ func (c *ConnectionClient) DropFunc(t *testing.T, id sdk.AccountObjectIdentifier
 				return false
 			}
 			return true
-		}, 10*time.Second, time.Second)
+		}, 20*time.Second, 2*time.Second)
 	}
 }
 

--- a/pkg/testacc/resource_secondary_connection_acceptance_test.go
+++ b/pkg/testacc/resource_secondary_connection_acceptance_test.go
@@ -4,7 +4,6 @@ package testacc
 
 import (
 	"testing"
-	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/stretchr/testify/assert"
 )
 
 // Recreation when promoting secondary to primary cannot be tested, because of the Terraform testing framework limitations.
@@ -27,7 +25,7 @@ import (
 
 func TestAcc_SecondaryConnection_Basic(t *testing.T) {
 	// TODO: [SNOW-1002023]: Unskip; Business Critical Snowflake Edition needed; also, different regions needed
-	t.Skipf("Skipped due to 003813 (23001): The connection cannot be failed over to an account in the same region")
+	// t.Skipf("Skipped due to 003813 (23001): The connection cannot be failed over to an account in the same region")
 
 	// create primary connection
 	connection, connectionCleanup := secondaryTestClient().Connection.Create(t)
@@ -46,14 +44,6 @@ func TestAcc_SecondaryConnection_Basic(t *testing.T) {
 	secondaryConnectionModel := model.SecondaryConnection("t", connection.ID().Name(), primaryConnectionAsExternalId.FullyQualifiedName())
 	secondaryConnectionModelWithComment := model.SecondaryConnection("t", connection.ID().Name(), primaryConnectionAsExternalId.FullyQualifiedName()).
 		WithComment(comment)
-
-	assert.Eventually(t, func() bool {
-		if _, err := testClient().Connection.CreateReplication(t, connection.ID(), primaryConnectionAsExternalId); err == nil {
-			testClient().Connection.DropFunc(t, connection.ID())()
-			return true
-		}
-		return false
-	}, 10*time.Second, time.Second)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,

--- a/templates/resources/secondary_connection.md.tmpl
+++ b/templates/resources/secondary_connection.md.tmpl
@@ -20,7 +20,7 @@ description: |-
 
 -> **Note** Instead of using fully_qualified_name, you can reference objects managed outside Terraform by constructing a correct ID, consult [identifiers guide](../guides/identifiers_rework_design_decisions#new-computed-fully-qualified-name-field-in-resources).
 
--> **Note** Creating secondary connections with `snowflake_primary_connection` should be done in two steps (terraform applies): first create the primary connection, then create the secondary connection. Snowflake needs some time to register the primary connection before you can create secondary connections based on it.
+-> **Note** Creating secondary connections with `snowflake_primary_connection` may fail and should be done in two steps (terraform applies): first create the primary connection, then create the secondary connection. Snowflake needs some time to register the primary connection before you can create secondary connections based on it. The provider is handling it internally with a retry mechanism, but the time to register may differ and be longer than retry's maximum wait time.
 
 -> **Note** To promote `snowflake_secondary_connection` to [`snowflake_primary_connection`](./primary_connection), resources need to be migrated manually. For guidance on removing and importing resources into the state check [resource migration](../guides/resource_migration). Remove the resource from the state with [terraform state rm](https://developer.hashicorp.com/terraform/cli/commands/state/rm), then promote it manually using:
     ```


### PR DESCRIPTION
## Changes
- Add retry for secondary_connection create operation so that it can be created with primary connection in one terraform apply
- Tested manually and with acceptance test
- Add migration guide entry
- Adjust resource docs