### PR TITLE
chore: Run functional tests after setting up Terraform

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,10 +113,6 @@ jobs:
         run: make test-unit
         if: ${{ !cancelled() && steps.create_config.conclusion == 'success' }}
 
-      - name: Run functional tests of the underlying terraform libraries
-        run: make test-functional
-        if: ${{ !cancelled() && steps.create_config.conclusion == 'success' }}
-
       - name: Run integration tests
         run: make test-integration
         if: ${{ !cancelled() && steps.create_config.conclusion == 'success' }}
@@ -138,6 +134,10 @@ jobs:
         with:
           terraform_version: 1.7.4
           terraform_wrapper: false
+
+      - name: Run functional tests of the underlying terraform libraries
+        run: make test-functional
+        if: ${{ !cancelled() && steps.setup_terraform.conclusion == 'success' }}
 
       - name: Run acceptance tests
         run: make test-acceptance

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test-acceptance: ## run acceptance tests
 	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test -run "^TestAcc_" -v -cover -timeout=150m ./pkg/testacc
 
 test-account-level-features: ## run integration and acceptance test modifying account
-	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=account_level_tests -run "^(TestAcc_|TestInt_)" -v -cover -timeout=30m ./pkg/testacc ./pkg/sdk/testint
+	TF_ACC=1 SF_TF_ACC_TEST_CONFIGURE_CLIENT_ONCE=true TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 SF_TF_ACC_TEST_ENABLE_ALL_PREVIEW_FEATURES=true go test --tags=account_level_tests -run "^(TestAcc_|TestInt_)" -v -cover -timeout=45m ./pkg/testacc ./pkg/sdk/testint
 
 test-integration: ## run SDK integration tests
 	TEST_SF_TF_REQUIRE_TEST_OBJECT_SUFFIX=1 TEST_SF_TF_REQUIRE_GENERATED_RANDOM_VALUE=1 go test -run "^TestInt_" -v -cover -timeout=60m ./pkg/sdk/testint


### PR DESCRIPTION
To avoid TF installation errors (e.g. https://github.com/snowflakedb/terraform-provider-snowflake/actions/runs/17153568002/job/48665189694)