### PR TITLE
chore: Clean up TODO comments left with "next PR" without issue number

### DIFF
--- a/pkg/acceptance/helpers/0_tests_setup_helpers.go
+++ b/pkg/acceptance/helpers/0_tests_setup_helpers.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 )
 
-// TODO [next PRs]: Use DropSafely
+// TODO [SNOW-2298254]: Use DropSafely
 func (c *TestClient) CreateTestDatabase(ctx context.Context, ifNotExists bool) (*sdk.Database, func(), error) {
 	id := c.Ids.DatabaseId()
 	cleanup := func() {

--- a/pkg/acceptance/helpers/stage_client.go
+++ b/pkg/acceptance/helpers/stage_client.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,7 +104,7 @@ func (c *StageClient) PutOnUserStageWithContent(t *testing.T, filename string, c
 	t.Helper()
 	ctx := context.Background()
 
-	path := testhelpers.TestFile(t, filename, []byte(content))
+	path := testfiles.TestFile(t, filename, []byte(content))
 
 	_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`PUT file://%s @~/ AUTO_COMPRESS = FALSE OVERWRITE = TRUE`, path))
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func (c *StageClient) PutInLocationWithContent(t *testing.T, stageLocation strin
 	t.Helper()
 	ctx := context.Background()
 
-	filePath := testhelpers.TestFile(t, filename, []byte(content))
+	filePath := testfiles.TestFile(t, filename, []byte(content))
 
 	_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`PUT file://%s %s AUTO_COMPRESS = FALSE OVERWRITE = TRUE`, filePath, stageLocation))
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func (c *StageClient) PutOnStageWithContent(t *testing.T, id sdk.SchemaObjectIde
 	t.Helper()
 	ctx := context.Background()
 
-	filePath := testhelpers.TestFile(t, filename, []byte(content))
+	filePath := testfiles.TestFile(t, filename, []byte(content))
 
 	_, err := c.context.client.ExecForTests(ctx, fmt.Sprintf(`PUT file://%s @%s AUTO_COMPRESS = FALSE OVERWRITE = TRUE`, filePath, id.FullyQualifiedName()))
 	require.NoError(t, err)

--- a/pkg/acceptance/helpers/tmp_toml_setup_helpers.go
+++ b/pkg/acceptance/helpers/tmp_toml_setup_helpers.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 )
 
 // TODO [SNOW-1827324]: add TestClient ref to each specific client, so that we enhance specific client and not the base one
@@ -106,7 +106,7 @@ func (c *TestClient) StoreTempTomlConfigWithProfile(t *testing.T, profile string
 	t.Helper()
 
 	toml := tomlProvider(profile)
-	configPath := testhelpers.TestFile(t, random.AlphaN(10), []byte(toml))
+	configPath := testfiles.TestFile(t, random.AlphaN(10), []byte(toml))
 	return &TmpTomlConfig{
 		Profile: profile,
 		Path:    configPath,
@@ -118,7 +118,7 @@ func (c *TestClient) StoreTempTomlConfigWithCustomPermissions(t *testing.T, toml
 
 	profile := random.AlphaN(6)
 	toml := tomlProvider(profile)
-	configPath := testhelpers.TestFileWithCustomPermissions(t, random.AlphaN(10), []byte(toml), permissions)
+	configPath := testfiles.TestFileWithCustomPermissions(t, random.AlphaN(10), []byte(toml), permissions)
 	return &TmpTomlConfig{
 		Profile: profile,
 		Path:    configPath,

--- a/pkg/acceptance/testfiles/helpers.go
+++ b/pkg/acceptance/testfiles/helpers.go
@@ -1,4 +1,4 @@
-package testhelpers
+package testfiles
 
 import (
 	"io/fs"
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// TODO [next PRs]: move this file
 // TestFile creates a temporary file with the given filename, data and with the default permissions.
 // The directory is automatically removed when the test and all its subtests complete.
 // Each subsequent call to t.TempDir returns a unique directory.

--- a/pkg/datasources/accounts.go
+++ b/pkg/datasources/accounts.go
@@ -34,7 +34,7 @@ var accountsSchema = map[string]*schema.Schema{
 						Schema: schemas.ShowAccountSchema,
 					},
 				},
-				// TODO(SNOW-1348092 - next prs): Add parameters
+				// TODO [SNOW-2298247]: Add parameters
 			},
 		},
 	},

--- a/pkg/internal/oswrapper/os_test.go
+++ b/pkg/internal/oswrapper/os_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReadFileSafeFailsForFileThatIsTooBig(t *testing.T) {
 	c := make([]byte, 11*1024*1024)
-	configPath := testhelpers.TestFile(t, "config", c)
+	configPath := testfiles.TestFile(t, "config", c)
 
 	_, err := oswrapper.ReadFileSafe(configPath, false)
 	require.ErrorContains(t, err, fmt.Sprintf("config file %s is too big - maximum allowed size is 10MB", configPath))
@@ -22,7 +22,7 @@ func TestReadFileSafeFailsForFileThatIsTooBig(t *testing.T) {
 
 func TestReadFileSafeCanSkipPermissionVerification(t *testing.T) {
 	exp := random.Bytes()
-	path := testhelpers.TestFileWithCustomPermissions(t, "config", exp, 0o755)
+	path := testfiles.TestFileWithCustomPermissions(t, "config", exp, 0o755)
 	act, err := oswrapper.ReadFileSafe(path, false)
 	require.NoError(t, err)
 	require.Equal(t, exp, act)
@@ -30,7 +30,7 @@ func TestReadFileSafeCanSkipPermissionVerification(t *testing.T) {
 
 func TestReadFileSafeWithPermissionVerificationFailsForFileThatIsTooBig(t *testing.T) {
 	c := make([]byte, 11*1024*1024)
-	configPath := testhelpers.TestFile(t, "config", c)
+	configPath := testfiles.TestFile(t, "config", c)
 
 	_, err := oswrapper.ReadFileSafe(configPath, true)
 	require.ErrorContains(t, err, fmt.Sprintf("config file %s is too big - maximum allowed size is 10MB", configPath))
@@ -67,7 +67,7 @@ func TestReadFileSafeFailsForFileWithTooWidePermissions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("reading file with too wide permissions %#o", tt.permissions), func(t *testing.T) {
-			path := testhelpers.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
+			path := testfiles.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
 			_, err := oswrapper.ReadFileSafe(path, true)
 			require.ErrorContains(t, err, fmt.Sprintf("config file %s has unsafe permissions", path))
 		})
@@ -88,7 +88,7 @@ func TestReadFileSafeFailsForFileWithTooRestrictivePermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("reading file with too restrictive permissions %#o", tt.permissions), func(t *testing.T) {
-			path := testhelpers.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
+			path := testfiles.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
 			_, err := oswrapper.ReadFileSafe(path, true)
 			require.ErrorContains(t, err, fmt.Sprintf("open %s: permission denied", path))
 		})
@@ -110,7 +110,7 @@ func TestReadFileSafeReadsFileWithCorrectPermissions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("reading file with correct permissions %#o", tt.permissions), func(t *testing.T) {
-			path := testhelpers.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
+			path := testfiles.TestFileWithCustomPermissions(t, "config", random.Bytes(), tt.permissions)
 			_, err := oswrapper.ReadFileSafe(path, true)
 			require.NoError(t, err)
 		})

--- a/pkg/manual_tests/windows/files_test.go
+++ b/pkg/manual_tests/windows/files_test.go
@@ -3,8 +3,8 @@ package windows_test
 import (
 	"testing"
 
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,7 +13,7 @@ func TestReadFileSafeWorksOnWindows(t *testing.T) {
 		t.Skip("reading files on other platforms is currently done in the sdk package")
 	}
 	exp := []byte("content")
-	configPath := testhelpers.TestFile(t, "config", exp)
+	configPath := testfiles.TestFile(t, "config", exp)
 
 	act, err := oswrapper.ReadFileSafe(configPath, true)
 	require.NoError(t, err)

--- a/pkg/manual_tests/windows/provider_test.go
+++ b/pkg/manual_tests/windows/provider_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/manual_tests"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
@@ -28,7 +28,7 @@ func TestAcc_Provider_tomlConfigIsTooPermissive(t *testing.T) {
 
 	permissions := fs.FileMode(0o755)
 
-	configPath := testhelpers.TestFileWithCustomPermissions(t, random.AlphaN(10), random.Bytes(), permissions)
+	configPath := testfiles.TestFileWithCustomPermissions(t, random.AlphaN(10), random.Bytes(), permissions)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: manual_tests.ManualTestProtoV6ProviderFactories,

--- a/pkg/resources/account_parameter.go
+++ b/pkg/resources/account_parameter.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/provider"
-
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/resources"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-// TODO(next prs): Deprecate account_parameter in favor of current_account (the list should stay as client.Parameters.SetAccountParameter was not updated to handle newly defined parameters).
+// TODO [SNOW-2298249]: Adjust client.Parameters.SetAccountParameter.
+// TODO [SNOW-2298249]: Continue handling parameters not available in current_account.
+// TODO [SNOW-2298249]: Ultimately unify with parameters list in current_account, these two resources should handle the same parameters list.
 var accountParameterSupportedParameters = []sdk.AccountParameter{
 	sdk.AccountParameterAllowClientMFACaching,
 	sdk.AccountParameterAllowIDToken,

--- a/pkg/schemas/account_parameters.go
+++ b/pkg/schemas/account_parameters.go
@@ -11,7 +11,7 @@ import (
 var (
 	ShowAccountParametersSchema = make(map[string]*schema.Schema)
 	accountParameters           = []sdk.AccountParameter{
-		// TODO(SNOW-1348092 - next prs): Add parameters
+		// TODO [SNOW-2298247]: Only session parameters are present here; add the missing ones while adding them to the accounts data source.
 		// session parameters
 		sdk.AccountParameterAbortDetachedQuery,
 		sdk.AccountParameterAutocommit,

--- a/pkg/sdk/config_test.go
+++ b/pkg/sdk/config_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,7 +35,7 @@ func TestLoadConfigFile(t *testing.T) {
 	})
 	bytes, err := cfg.MarshalToml()
 	require.NoError(t, err)
-	configPath := testhelpers.TestFile(t, "config", bytes)
+	configPath := testfiles.TestFile(t, "config", bytes)
 
 	m, err := LoadConfigFile[*ConfigDTO](configPath, true)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestLoadConfigFileWithUnknownFields(t *testing.T) {
 	unknown='TEST_ACCOUNT'
 	account_name='TEST_ACCOUNT'
 	`
-	configPath := testhelpers.TestFile(t, "config", []byte(c))
+	configPath := testfiles.TestFile(t, "config", []byte(c))
 
 	m, err := LoadConfigFile[*ConfigDTO](configPath, true)
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func Test_LoadConfigFile_triValueBooleanDefault(t *testing.T) {
 	)
 	bytes, err := cfg.MarshalToml()
 	require.NoError(t, err)
-	configPath := testhelpers.TestFile(t, "config", bytes)
+	configPath := testfiles.TestFile(t, "config", bytes)
 
 	m, err := LoadConfigFile[*ConfigDTO](configPath, true)
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func Test_LoadConfigFile_triValueBooleanSet(t *testing.T) {
 			)
 			bytes, err := cfg.MarshalToml()
 			require.NoError(t, err)
-			configPath := testhelpers.TestFile(t, "config", bytes)
+			configPath := testfiles.TestFile(t, "config", bytes)
 
 			m, err := LoadConfigFile[*ConfigDTO](configPath, true)
 			require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestLoadConfigFileWithInvalidFieldTypeFails(t *testing.T) {
 		[default]
 		%s=42
 		`, tt.fieldName)
-			configPath := testhelpers.TestFile(t, "config", []byte(config))
+			configPath := testfiles.TestFile(t, "config", []byte(config))
 
 			_, err := LoadConfigFile[*ConfigDTO](configPath, true)
 			require.ErrorContains(t, err, fmt.Sprintf("toml: cannot decode TOML integer into struct field sdk.ConfigDTO.%s of type %s", tt.name, tt.wantType))
@@ -190,7 +190,7 @@ func TestLoadConfigFileWithInvalidFieldTypeIntFails(t *testing.T) {
 		[default]
 		%s=value
 		`, tt.fieldName)
-			configPath := testhelpers.TestFile(t, "config", []byte(config))
+			configPath := testfiles.TestFile(t, "config", []byte(config))
 
 			_, err := LoadConfigFile[*ConfigDTO](configPath, true)
 			require.ErrorContains(t, err, "toml: incomplete number")
@@ -255,7 +255,7 @@ func TestLoadConfigFileWithInvalidTOMLFails(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configPath := testhelpers.TestFile(t, "config", []byte(tt.config))
+			configPath := testfiles.TestFile(t, "config", []byte(tt.config))
 
 			_, err := LoadConfigFile[*ConfigDTO](configPath, true)
 			require.ErrorContains(t, err, tt.err)
@@ -312,7 +312,7 @@ func TestProfileConfig(t *testing.T) {
 	bytes, err := cfg.MarshalToml()
 	require.NoError(t, err)
 
-	configPath := testhelpers.TestFile(t, "config", bytes)
+	configPath := testfiles.TestFile(t, "config", bytes)
 
 	t.Run("with found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)

--- a/pkg/sdk/legacy_config_test.go
+++ b/pkg/sdk/legacy_config_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/snowflakedb/gosnowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +33,7 @@ func TestLoadConfigFileLegacy(t *testing.T) {
 	})
 	bytes, err := cfg.MarshalToml()
 	require.NoError(t, err)
-	configPath := testhelpers.TestFile(t, "config", bytes)
+	configPath := testfiles.TestFile(t, "config", bytes)
 
 	m, err := LoadConfigFile[*LegacyConfigDTO](configPath, true)
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestLoadConfigFileWithUnknownFieldsLegacy(t *testing.T) {
 	unknown='TEST_ACCOUNT'
 	accountname='TEST_ACCOUNT'
 	`
-	configPath := testhelpers.TestFile(t, "config", []byte(c))
+	configPath := testfiles.TestFile(t, "config", []byte(c))
 
 	m, err := LoadConfigFile[*LegacyConfigDTO](configPath, true)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func TestLoadConfigFileWithInvalidFieldTypeFailsLegacy(t *testing.T) {
 		[default]
 		%s=42
 		`, tt.fieldName)
-			configPath := testhelpers.TestFile(t, "config", []byte(config))
+			configPath := testfiles.TestFile(t, "config", []byte(config))
 
 			_, err := LoadConfigFile[*LegacyConfigDTO](configPath, true)
 			require.ErrorContains(t, err, fmt.Sprintf("toml: cannot decode TOML integer into struct field sdk.LegacyConfigDTO.%s of type %s", tt.name, tt.wantType))
@@ -137,7 +137,7 @@ func TestLoadConfigFileWithInvalidFieldTypeIntFailsLegacy(t *testing.T) {
 		[default]
 		%s=value
 		`, tt.fieldName)
-			configPath := testhelpers.TestFile(t, "config", []byte(config))
+			configPath := testfiles.TestFile(t, "config", []byte(config))
 
 			_, err := LoadConfigFile[*LegacyConfigDTO](configPath, true)
 			require.ErrorContains(t, err, "toml: incomplete number")
@@ -202,7 +202,7 @@ func TestLoadConfigFileWithInvalidTOMLFailsLegacy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configPath := testhelpers.TestFile(t, "config", []byte(tt.config))
+			configPath := testfiles.TestFile(t, "config", []byte(tt.config))
 
 			_, err := LoadConfigFile[*LegacyConfigDTO](configPath, true)
 			require.ErrorContains(t, err, tt.err)
@@ -257,7 +257,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 	bytes, err := cfg.MarshalToml()
 	require.NoError(t, err)
 	c := string(bytes)
-	configPath := testhelpers.TestFile(t, "config", []byte(c))
+	configPath := testfiles.TestFile(t, "config", []byte(c))
 
 	t.Run("with found profile", func(t *testing.T) {
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
@@ -337,7 +337,7 @@ func TestProfileConfigLegacy(t *testing.T) {
 		accountname='TEST_ACCOUNT'
 		organizationname='TEST_ORG'
 		`
-		configPath := testhelpers.TestFile(t, "config", []byte(c))
+		configPath := testfiles.TestFile(t, "config", []byte(c))
 
 		t.Setenv(snowflakeenvs.ConfigPath, configPath)
 

--- a/pkg/sdk/listings_def.go
+++ b/pkg/sdk/listings_def.go
@@ -366,8 +366,8 @@ var ListingsDef = g.NewInterface(
 			WithValidation(g.ValidIdentifier, "name"),
 	)
 
-	// TODO(next prs): Organization listing may have its interface, but most of the operations would be pass through functions to the Listings interface
-	// TODO(next prs): Show available listings
-	// TODO(next prs): Describe available listing
-	// TODO(next prs): Listing manifest builder - https://docs.snowflake.com/en/progaccess/listing-manifest-reference
-	// TODO(next prs): Test mapping functions (ToListingRevision and ToListingState)
+	// TODO [SNOW-2236968]: Organization listing may have its interface, but most of the operations would be pass through functions to the Listings interface
+	// TODO [SNOW-2236968]: Show available listings
+	// TODO [SNOW-2236968]: Describe available listing
+	// TODO [SNOW-2236968]: Listing manifest builder - https://docs.snowflake.com/en/progaccess/listing-manifest-reference
+	// TODO [SNOW-2236968]: Test mapping functions (ToListingRevision and ToListingState)

--- a/pkg/sdk/testint/masking_policy_integration_test.go
+++ b/pkg/sdk/testint/masking_policy_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO [next PR]: merge these tests
+// TODO [SNOW-2298256]: merge these tests
 func TestInt_MaskingPoliciesShow(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)

--- a/pkg/sdk/testint/row_access_policies_gen_integration_test.go
+++ b/pkg/sdk/testint/row_access_policies_gen_integration_test.go
@@ -300,7 +300,7 @@ func TestInt_RowAccessPoliciesShowByID(t *testing.T) {
 	})
 }
 
-// TODO [next PR]: improve this test
+// TODO [SNOW-2298259]: improve this test; follow functions/procedures tests
 func TestInt_RowAccessPoliciesDescribe(t *testing.T) {
 	client := testClient(t)
 	ctx := testContext(t)

--- a/pkg/sdk/testint/tables_integration_test.go
+++ b/pkg/sdk/testint/tables_integration_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testdatatypes"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeroles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk/datatypes"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -209,7 +209,7 @@ func TestInt_Table(t *testing.T) {
 		stage, stageCleanup := testClientHelper().Stage.CreateStage(t)
 		t.Cleanup(stageCleanup)
 
-		filePath := testhelpers.TestFile(t, "data.csv", []byte(` [{"name": "column1", "type" "INTEGER"},
+		filePath := testfiles.TestFile(t, "data.csv", []byte(` [{"name": "column1", "type" "INTEGER"},
 									 {"name": "column2", "type" "INTEGER"} ]`))
 
 		_, err := client.ExecForTests(ctx, fmt.Sprintf("PUT file://%s @%s", filePath, stage.ID().FullyQualifiedName()))

--- a/pkg/testacc/0_setup_helper_funcs_test.go
+++ b/pkg/testacc/0_setup_helper_funcs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/snowflakedb/gosnowflake"
 )
 
-// TODO [next PRs]: contents of this file may be potentially reused for both integration and acceptance tests setups
+// TODO [SNOW-2298294]: contents of this file may be potentially reused for both integration and acceptance tests setups
 
 // timer measures time from invocation point to the end of method.
 // It's supposed to be used like:

--- a/pkg/testacc/0_setup_test.go
+++ b/pkg/testacc/0_setup_test.go
@@ -28,8 +28,8 @@ var (
 	NonExistingSchemaObjectIdentifier   = sdk.NewSchemaObjectIdentifier(TestDatabaseName, TestSchemaName, "does_not_exist")
 )
 
-// TODO [next PRs]: make logging level configurable
-// TODO [next PRs]: adjust during logger rework (e.g. use in model builders); maybe use log/slog
+// TODO [SNOW-1325306]: make logging level configurable
+// TODO [SNOW-1325306]: adjust during logger rework (e.g. use in model builders); maybe use log/slog
 var accTestLog = log.New(os.Stdout, "", log.LstdFlags)
 
 type acceptanceTestContext struct {
@@ -127,7 +127,7 @@ func (atc *acceptanceTestContext) initialize() error {
 	}
 	atc.warehouse = wh
 
-	// TODO [next PRs]: what do we do with SimplifiedIntegrationTestsSetup
+	// TODO [SNOW-1763603]: what do we do with SimplifiedIntegrationTestsSetup
 	if os.Getenv(string(testenvs.SimplifiedIntegrationTestsSetup)) == "" {
 		secondaryConfig, secondaryClient, err := setUpSdkClient(testprofiles.Secondary, "acceptance")
 		if err != nil {

--- a/pkg/testacc/0_setup_test.go
+++ b/pkg/testacc/0_setup_test.go
@@ -81,8 +81,8 @@ func setup() {
 	}
 }
 
-// TODO [next PRs]: extract more convenience methods for reuse
-// TODO [next PRs]: potentially extract test context logic into separate directory
+// TODO [SNOW-2298294]: extract more convenience methods for reuse
+// TODO [SNOW-2298294]: potentially extract test context logic into separate directory
 func (atc *acceptanceTestContext) initialize() error {
 	accTestLog.Printf("[INFO] Initializing acceptance test context")
 

--- a/pkg/testacc/1_setup_provider_test.go
+++ b/pkg/testacc/1_setup_provider_test.go
@@ -33,7 +33,7 @@ var (
 	lastConfiguredProviderContext *internalprovider.Context
 )
 
-// TODO [next PRs]: rework this when working on terraform plugin framework PoC
+// TODO [SNOW-2298291]: rework this when working on terraform plugin framework PoC
 func setUpProvider() error {
 	TestAccProvider = provider.Provider()
 	TestAccProvider.ConfigureContextFunc = configureProviderWithConfigCache
@@ -60,7 +60,7 @@ func setUpProvider() error {
 	return nil
 }
 
-// TODO [next PRs]: investigate this (it was moved from the old testing.go file)
+// TODO [SNOW-2298291]: investigate this (it was moved from the old testing.go file)
 // if we do not reuse the created objects there is no `Previously configured provider being re-configured.` warning
 // currently left for possible usage after other improvements
 var testAccProtoV6ProviderFactoriesNew = map[string]func() (tfprotov6.ProviderServer, error){
@@ -72,7 +72,6 @@ var testAccProtoV6ProviderFactoriesNew = map[string]func() (tfprotov6.ProviderSe
 	},
 }
 
-// TODO [next PRs]: it's currently an exact copy of acceptance.ConfigureProviderWithConfigCache; adjust after moving the tests
 func configureProviderWithConfigCache(ctx context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
 	accTestEnabled, err := oswrapper.GetenvBool("TF_ACC")
 	if err != nil {

--- a/pkg/testacc/2_check_destroy_test.go
+++ b/pkg/testacc/2_check_destroy_test.go
@@ -17,10 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// TODO [next PRs]: this file is currently almost exact copy of check_destroy file in old acceptance package:
-// 	- the package name was changed
-//  - TestClient() -> testClient()
-
 func ComposeCheckDestroy(t *testing.T, resources ...resources.Resource) func(*terraform.State) error {
 	t.Helper()
 

--- a/pkg/testacc/2_provider_helpers_test.go
+++ b/pkg/testacc/2_provider_helpers_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO [next PRs]: this file contains all the convenience methods from testing.go from acceptance package
-
-// TODO [next PRs]: function acceptance.TestAccPreCheck was needed for the database, schema, and warehouse creation; it's not needed when TestMain is used; it was left for now, as we may want to do other validations here (and not to do a big revolution in all the acceptance tests that will be copied)
+// TODO [SNOW-2298287]: function acceptance.TestAccPreCheck was needed for the database, schema, and warehouse creation; it's not needed when TestMain is used; it was left for now, as we may want to do other validations here (and not to do a big revolution in all the acceptance tests that will be copied)
 func TestAccPreCheck(t *testing.T) {
 	t.Helper()
 }

--- a/pkg/testacc/provider_acceptance_test.go
+++ b/pkg/testacc/provider_acceptance_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/helpers/random"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testenvs"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testfiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testvars"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/oswrapper"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/snowflakeenvs"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/provider/previewfeatures"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
-	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/testhelpers"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -436,7 +436,7 @@ func TestAcc_Provider_tomlConfigIsTooPermissive(t *testing.T) {
 
 	permissions := fs.FileMode(0o755)
 
-	configPath := testhelpers.TestFileWithCustomPermissions(t, random.AlphaN(10), random.Bytes(), permissions)
+	configPath := testfiles.TestFileWithCustomPermissions(t, random.AlphaN(10), random.Bytes(), permissions)
 	providerModel := providermodel.SnowflakeProvider().WithProfile(configPath)
 
 	resource.Test(t, resource.TestCase{

--- a/pkg/testacc/resource_masking_policy_acceptance_test.go
+++ b/pkg/testacc/resource_masking_policy_acceptance_test.go
@@ -919,7 +919,7 @@ func TestAcc_MaskingPolicy_dataType_externalChange(t *testing.T) {
 					// had to update the body too, as otherwise error is returned
 					// 090207 (42601): Declared return type 'NUMBER(38,0)' is incompatible with actual return type 'VARCHAR(5)'
 					// we could later suppress the body changes to be sure what triggers the changes
-					// TODO [next PR]: suppress the changes
+					// TODO [SNOW-2298286]: suppress the body changes
 					testClient().MaskingPolicy.CreateOrReplaceMaskingPolicyWithOptions(t, id, externalSignature, testdatatypes.DataTypeNumber, updatedBody, &sdk.CreateMaskingPolicyOptions{})
 				},
 				ConfigPlanChecks: resource.ConfigPlanChecks{

--- a/pkg/testacc/resource_view_acceptance_test.go
+++ b/pkg/testacc/resource_view_acceptance_test.go
@@ -434,7 +434,7 @@ func TestAcc_View_recursive(t *testing.T) {
 	})
 }
 
-// TODO [next PR]: currently this test is always skipped, try to fix the set up
+// TODO [SNOW-2298268]: currently, this test is always skipped, try to fix the set up
 func TestAcc_View_temporary(t *testing.T) {
 	t.Setenv(string(testenvs.ConfigureClientOnce), "")
 	// we use one configured client, so a temporary view should be visible after creation


### PR DESCRIPTION
Add issue numbers for each TODO left with "next PR" annotation. Removed some. Solved the one with the package move (file helpers).