### PR TITLE
chore: Fix unsafe query integration test

### DIFF
--- a/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
+++ b/pkg/sdk/testint/client_unsafe_extensions_integration_test.go
@@ -15,7 +15,11 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 	ctx := testContext(t)
 
 	t.Run("test show databases", func(t *testing.T) {
-		sql := fmt.Sprintf("SHOW DATABASES LIKE '%%%s%%'", testClientHelper().Ids.DatabaseId().Name())
+		// creating new database on purpose (using the precreated database could lead to matching database from other pipeline, e.g. account level one where the name differs only by the "AL" suffix)
+		db, dbCleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
+		t.Cleanup(dbCleanup)
+
+		sql := fmt.Sprintf("SHOW DATABASES LIKE '%%%s%%'", db.ID().Name())
 		results, err := client.QueryUnsafe(ctx, sql)
 		require.NoError(t, err)
 
@@ -29,7 +33,7 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 		require.NotNil(t, row["comment"])
 		require.NotNil(t, row["is_default"])
 
-		assert.Equal(t, testClientHelper().Ids.DatabaseId().Name(), *row["name"])
+		assert.Equal(t, db.ID().Name(), *row["name"])
 		assert.NotEmpty(t, *row["created_on"])
 		assert.Equal(t, "STANDARD", *row["kind"])
 		assert.Equal(t, "ACCOUNTADMIN", *row["owner"])
@@ -39,11 +43,11 @@ func TestInt_Client_UnsafeQuery(t *testing.T) {
 	})
 
 	t.Run("test more results", func(t *testing.T) {
-		db1, db1Cleanup := testClientHelper().Database.CreateDatabase(t)
+		db1, db1Cleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
 		t.Cleanup(db1Cleanup)
-		db2, db2Cleanup := testClientHelper().Database.CreateDatabase(t)
+		db2, db2Cleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
 		t.Cleanup(db2Cleanup)
-		db3, db3Cleanup := testClientHelper().Database.CreateDatabase(t)
+		db3, db3Cleanup := testClientHelper().Database.CreateDatabaseWithParametersSet(t)
 		t.Cleanup(db3Cleanup)
 
 		sql := "SHOW DATABASES"


### PR DESCRIPTION
Create a dedicated database to match only one result (using the precreated database could lead to matching a database from another pipeline, e.g., account level one, where the name differs only by the "AL" suffix).
Also, create databases with parameters.