### PR TITLE
chore: Address skipped tests (SNOW-2010844)

### DIFF
--- a/pkg/testacc/resource_network_policy_attachment_acceptance_test.go
+++ b/pkg/testacc/resource_network_policy_attachment_acceptance_test.go
@@ -59,8 +59,7 @@ func TestAcc_NetworkPolicyAttachmentUser(t *testing.T) {
 }
 
 func TestAcc_NetworkPolicyAttachmentAccount(t *testing.T) {
-	// TODO [SNOW-2010844]: unskip
-	t.Skip("Skipping as it messes with the account level setting. Should be moved to manual tests and later invoked on a brand new account.")
+	testClient().EnsureValidNonProdAccountIsUsed(t)
 
 	policyNameAccount := strings.ToUpper(acctest.RandStringFromCharSet(10, acctest.CharSetAlpha))
 

--- a/pkg/testacc/resource_object_parameter_acceptance_test.go
+++ b/pkg/testacc/resource_object_parameter_acceptance_test.go
@@ -48,8 +48,8 @@ resource "snowflake_object_parameter" "p" {
 }
 
 func TestAcc_ObjectParameterAccount(t *testing.T) {
-	// TODO [SNOW-2010844]: unskip
-	t.Skip("Skipping temporarily as it messes with the account level setting.")
+	// TODO [SNOW-1348325]: Unskip during resource stabilization.
+	t.Skip("Skipping temporarily as it messes with the account level setting. The current cleanup is incorrect, so we shouldn't run it even on the account level tests.")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
- Postpone unskip of `TestAcc_ObjectParameterAccount` until `snowflake_object_parameter` rework (due to broken removal logic)
- Run `TestAcc_NetworkPolicyAttachmentAccount` conditionally using `EnsureValidNonProdAccountIsUsed` check