### PR TITLE
chore: Unskip or remove BCR/functionality missing related tests

### DIFF
--- a/pkg/testacc/resource_user_acceptance_test.go
+++ b/pkg/testacc/resource_user_acceptance_test.go
@@ -1038,154 +1038,6 @@ func TestAcc_User_handleExternalTypeChange(t *testing.T) {
 }
 
 func TestAcc_User_handleChangesToDefaultSecondaryRoles(t *testing.T) {
-	t.Skip("Ordering needs to be changed after BCR 2024_08 general availability.")
-
-	userId := testClient().Ids.RandomAccountObjectIdentifier()
-
-	userModelEmpty := model.UserWithDefaultMeta(userId.Name())
-	userModelWithOptionAll := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionAll)
-	userModelWithOptionNone := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOptionEnum(sdk.SecondaryRolesOptionNone)
-	userModelLowercaseValue := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOption("all")
-	userModelIncorrectValue := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOption("OTHER")
-	userModelEmptyValue := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOption("")
-	userModelNullValue := model.UserWithDefaultMeta(userId.Name()).WithDefaultSecondaryRolesOptionValue(config.ReplacementPlaceholderVariable(config.SnowflakeProviderConfigNull))
-
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.RequireAbove(tfversion.Version1_5_0),
-		},
-		CheckDestroy: CheckDestroy(t, resources.User),
-		Steps: []resource.TestStep{
-			// 1. create without default secondary roles option set (DEFAULT will be used)
-			{
-				Config: config.FromModels(t, userModelEmpty),
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelEmpty.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(""),
-				),
-			},
-			// 2. add default secondary roles NONE (expecting change because null != [] on Snowflake side)
-			{
-				Config: config.FromModels(t, userModelWithOptionNone),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectNonEmptyPlan(),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelWithOptionAll.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionNone),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(`[]`),
-				),
-			},
-			// 3. add default secondary roles ALL
-			{
-				Config: config.FromModels(t, userModelWithOptionAll),
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelWithOptionAll.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(`["ALL"]`),
-				),
-			},
-			// 4. change to lowercase (no changes)
-			{
-				Config: config.FromModels(t, userModelLowercaseValue),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectEmptyPlan(),
-					},
-				},
-			},
-			// 5. unset externally
-			{
-				PreConfig: func() {
-					testClient().User.UnsetDefaultSecondaryRoles(t, userId)
-				},
-				Config: config.FromModels(t, userModelWithOptionAll),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.ExpectChange(userModelWithOptionAll.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("DEFAULT"), sdk.String("ALL")),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelWithOptionAll.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(`["ALL"]`),
-				),
-			},
-			// 6. unset in config (change)
-			{
-				Config: config.FromModels(t, userModelEmpty),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.ExpectChange(userModelEmpty.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("ALL"), sdk.String("DEFAULT")),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelEmpty.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(""),
-				),
-			},
-			// 7. incorrect value used
-			{
-				Config:      config.FromModels(t, userModelIncorrectValue),
-				ExpectError: regexp.MustCompile("invalid secondary roles option: OTHER"),
-			},
-			// 8. set to empty in config (invalid)
-			{
-				Config:      config.FromModels(t, userModelEmptyValue),
-				ExpectError: regexp.MustCompile("invalid secondary roles option: "),
-			},
-			// 9. set in config to NONE (change)
-			{
-				Config: config.FromModels(t, userModelWithOptionNone),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.ExpectChange(userModelWithOptionNone.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("DEFAULT"), sdk.String("NONE")),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelWithOptionNone.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionNone),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles("[]"),
-				),
-			},
-			// 10. unset in config (change)
-			{
-				Config: config.FromModels(t, userModelEmpty),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.ExpectChange(userModelEmpty.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("NONE"), sdk.String("DEFAULT")),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelEmpty.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(""),
-				),
-			},
-			// 11. add default secondary roles ALL
-			{
-				Config: config.FromModels(t, userModelWithOptionAll),
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelWithOptionAll.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionAll),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(`["ALL"]`),
-				),
-			},
-			// 12. set to null value in config (change)
-			{
-				Config: config.FromModels(t, userModelNullValue),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						planchecks.ExpectChange(userModelNullValue.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("ALL"), sdk.String("DEFAULT")),
-					},
-				},
-				Check: assertThat(t,
-					resourceassert.UserResource(t, userModelNullValue.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault),
-					objectassert.User(t, userId).HasDefaultSecondaryRoles(""),
-				),
-			},
-		},
-	})
-}
-
-func TestAcc_User_handleChangesToDefaultSecondaryRoles_bcr202408(t *testing.T) {
 	userId := testClient().Ids.RandomAccountObjectIdentifier()
 
 	userModelEmpty := model.UserWithDefaultMeta(userId.Name())
@@ -1213,12 +1065,12 @@ func TestAcc_User_handleChangesToDefaultSecondaryRoles_bcr202408(t *testing.T) {
 			},
 			// 2. add default secondary roles ALL (expecting no change)
 			{
+				Config: config.FromModels(t, userModelWithOptionAll),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
 					},
 				},
-				Config: config.FromModels(t, userModelWithOptionAll),
 			},
 			// 3. change to lowercase (change because we have DEFAULT in state because previous step was suppressed so none of the suppressors NormalizeAndCompare nor IgnoreChangeToCurrentSnowflakeValueInShowWithMapping suppresses it; it can be made better later)
 			{
@@ -1317,6 +1169,11 @@ func TestAcc_User_handleChangesToDefaultSecondaryRoles_bcr202408(t *testing.T) {
 			// 12. set to null value in config (change)
 			{
 				Config: config.FromModels(t, userModelNullValue),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						planchecks.ExpectChange(userModelNullValue.ResourceReference(), "default_secondary_roles_option", tfjson.ActionUpdate, sdk.String("NONE"), sdk.String("DEFAULT")),
+					},
+				},
 				Check: assertThat(t,
 					resourceassert.UserResource(t, userModelEmpty.ResourceReference()).HasDefaultSecondaryRolesOption(sdk.SecondaryRolesOptionDefault),
 					objectassert.User(t, userId).HasDefaultSecondaryRoles(`["ALL"]`),


### PR DESCRIPTION
- Remove the duplicated user default secondary roles test and rename the proper one
- Unskip privilege granting to future streamlits (account and database role)