### PR TITLE
chore: Adjust warehouses after the changes in Snowflake

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -24,6 +24,14 @@ for changes required after enabling given [Snowflake BCR Bundle](https://docs.sn
 > [!TIP]
 > If you're still using the `Snowflake-Labs/snowflake` source, see [Upgrading from Snowflake-Labs Provider](./SNOWFLAKEDB_MIGRATION.md) to upgrade to the snowflakedb namespace.
 
+## v2.7.0 ➞ v2.7.1
+
+### Changed handling of unset `generation` and `resource_constraint` fields in the `warehouse` resource
+
+Previously, due to limitations in Snowflake, when one of `generation` or `resource_constraint` field was unset in the configuration, the provider used `SET RESOURCE_CONSTRAINT=STANDARD_GEN_1` and `SET RESOURCE_CONSTRAINT=MEMORY_16X`, respectively. Now, the `UNSET` operation is supported for this field, and it is used in the provider in handling `generation` and `resource_constraint`.
+
+No changes in configuration and state are required.
+
 ## v2.6.x ➞ v2.7.0
 
 ### *(new feature)* Added support for generation 2 Standard warehouses and resource constraints for Snowpark-optimized warehouses

--- a/pkg/resources/warehouse.go
+++ b/pkg/resources/warehouse.go
@@ -666,9 +666,7 @@ func UpdateWarehouse(ctx context.Context, d *schema.ResourceData, meta any) diag
 					}
 					set.ResourceConstraint = &resourceConstraint
 				} else {
-					// TODO [SNOW-2330776]: UNSET of resource constraint does not work
-					// unset.ResourceConstraint = sdk.Bool(true)
-					set.ResourceConstraint = sdk.Pointer(sdk.WarehouseResourceConstraintMemory16X)
+					unset.ResourceConstraint = sdk.Bool(true)
 				}
 			} else {
 				log.Printf("[DEBUG] resource constraint is not supported for %s warehouses, ignoring", warehouseType)
@@ -701,9 +699,7 @@ func UpdateWarehouse(ctx context.Context, d *schema.ResourceData, meta any) diag
 				}
 				set.ResourceConstraint = &resourceConstraint
 			} else {
-				// TODO [SNOW-2330776]: UNSET of resource constraint does not work
-				// unset.ResourceConstraint = sdk.Bool(true)
-				set.ResourceConstraint = sdk.Pointer(sdk.WarehouseResourceConstraintStandardGen1)
+				unset.ResourceConstraint = sdk.Bool(true)
 			}
 		} else {
 			log.Printf("[DEBUG] generation is not supported for %s warehouses, ignoring", warehouseTypeRaw)

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -452,7 +452,7 @@ func TestInt_Warehouses(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, sdk.WarehouseTypeSnowparkOptimized, returnedWarehouse.Type)
 		assert.Nil(t, returnedWarehouse.Generation)
-		assert.NotNil(t, returnedWarehouse.ResourceConstraint)
+		require.NotNil(t, returnedWarehouse.ResourceConstraint)
 		assert.Equal(t, sdk.WarehouseResourceConstraintMemory16X, *returnedWarehouse.ResourceConstraint)
 
 		alterOptions := &sdk.AlterWarehouseOptions{
@@ -478,7 +478,7 @@ func TestInt_Warehouses(t *testing.T) {
 
 		returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
 		require.NoError(t, err)
-		assert.NotNil(t, returnedWarehouse.ResourceConstraint)
+		require.NotNil(t, returnedWarehouse.ResourceConstraint)
 		assert.Equal(t, sdk.WarehouseResourceConstraintMemory16X, *returnedWarehouse.ResourceConstraint)
 	})
 

--- a/pkg/sdk/testint/warehouses_integration_test.go
+++ b/pkg/sdk/testint/warehouses_integration_test.go
@@ -470,16 +470,16 @@ func TestInt_Warehouses(t *testing.T) {
 			HasSize(sdk.WarehouseSizeMedium),
 		)
 
-		// TODO [SNOW-1473453]: uncomment and test when UNSET starts working correctly (expecting to unset to default MEMORY_16X)
-		// alterOptions = &sdk.AlterWarehouseOptions{
-		//	Unset: &sdk.WarehouseUnset{ResourceConstraint: sdk.Bool(true)},
-		// }
-		// err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
-		// require.NoError(t, err)
-		//
-		// returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
-		// require.NoError(t, err)
-		// assert.Equal(t, *sdk.WarehouseResourceConstraintMemory1X, returnedWarehouse.ResourceConstraint)
+		alterOptions = &sdk.AlterWarehouseOptions{
+			Unset: &sdk.WarehouseUnset{ResourceConstraint: sdk.Bool(true)},
+		}
+		err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
+		require.NoError(t, err)
+
+		returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
+		require.NoError(t, err)
+		assert.NotNil(t, returnedWarehouse.ResourceConstraint)
+		assert.Equal(t, sdk.WarehouseResourceConstraintMemory16X, *returnedWarehouse.ResourceConstraint)
 	})
 
 	t.Run("alter: set and unset generation", func(t *testing.T) {
@@ -509,16 +509,16 @@ func TestInt_Warehouses(t *testing.T) {
 			HasType(sdk.WarehouseTypeStandard),
 		)
 
-		// TODO [SNOW-1473453]: uncomment and test when UNSET starts working correctly (expecting to unset to default STANDARD_GEN_1)
-		// alterOptions = &sdk.AlterWarehouseOptions{
-		//	Unset: &sdk.WarehouseUnset{ResourceConstraint: sdk.Bool(true)},
-		// }
-		// err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
-		// require.NoError(t, err)
-		//
-		// returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
-		// require.NoError(t, err)
-		// assert.Equal(t, *sdk.WarehouseResourceConstraintStandardGen1, returnedWarehouse.Generation)
+		alterOptions = &sdk.AlterWarehouseOptions{
+			Unset: &sdk.WarehouseUnset{ResourceConstraint: sdk.Bool(true)},
+		}
+		err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
+		require.NoError(t, err)
+
+		returnedWarehouse, err = client.Warehouses.ShowByID(ctx, warehouse.ID())
+		require.NoError(t, err)
+		assert.NotNil(t, returnedWarehouse.Generation)
+		assert.Equal(t, sdk.WarehouseGenerationStandardGen1, *returnedWarehouse.Generation)
 	})
 
 	t.Run("alter: prove problems with unset auto suspend", func(t *testing.T) {
@@ -583,32 +583,6 @@ func TestInt_Warehouses(t *testing.T) {
 		// TODO [SNOW-1473453]: change when UNSET starts working correctly (expecting to unset to default auto resume TRUE)
 		// assert.Equal(t, true, returnedWarehouse.AutoResume)
 		assert.Equal(t, false, returnedWarehouse.AutoResume)
-	})
-
-	t.Run("alter: prove problems with unset resource constraint", func(t *testing.T) {
-		// new warehouse created on purpose
-		id := testClientHelper().Ids.RandomAccountObjectIdentifier()
-		warehouse, warehouseCleanup := testClientHelper().Warehouse.CreateWarehouseWithOptions(t, id, &sdk.CreateWarehouseOptions{
-			WarehouseSize: sdk.Pointer(sdk.WarehouseSizeMedium),
-		})
-		t.Cleanup(warehouseCleanup)
-
-		alterOptions := &sdk.AlterWarehouseOptions{
-			Unset: &sdk.WarehouseUnset{ResourceConstraint: sdk.Bool(true)},
-		}
-		err := client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
-		require.ErrorContains(t, err, "invalid type of property 'null' for 'RESOURCE_CONSTRAINT'")
-
-		// The same happens for SNOWPARK_OPTIMIZED type
-		err = client.Warehouses.Alter(ctx, warehouse.ID(), &sdk.AlterWarehouseOptions{
-			Set: &sdk.WarehouseSet{
-				WarehouseType: sdk.Pointer(sdk.WarehouseTypeSnowparkOptimized),
-			},
-		})
-		require.NoError(t, err)
-
-		err = client.Warehouses.Alter(ctx, warehouse.ID(), alterOptions)
-		require.ErrorContains(t, err, "invalid type of property 'null' for 'RESOURCE_CONSTRAINT'")
 	})
 
 	t.Run("alter: rename", func(t *testing.T) {


### PR DESCRIPTION
- Use UNSET instead of SET with a default value in the warehouse resource.
- Update the integration tests.