### PR TITLE
chore: Add common filtering flags to each generator

### DIFF
--- a/pkg/internal/genhelpers/README.md
+++ b/pkg/internal/genhelpers/README.md
@@ -39,11 +39,9 @@ To create a new generator:
    - `--dry-run` allowing to print the generated content to the command line instead of saving it to files
    - `--verbose` allowing to see the all the additional debug logs
 
+[//]: # (TODO [this PR]: Update this description)
+
 ### Next steps
-
-##### Known limitations
-
-- Currently, only 3 generators reuse the same flow; we need to include more to have more observations
 
 ##### Improvements
 
@@ -54,9 +52,5 @@ Functional improvements:
 Implementation improvements:
 - add acceptance test for a `testStruct` (the one from [struct_details_extractor_test.go](./struct_details_extractor_test.go)) for the whole generation flow
 - add description to all publicly available structs and functions (multiple TODOs left)
-- introduce a more meaningful function for the `GenerationModel` interface (TODO left in the `generator.go`)
-- tackle the temporary hacky solution to allow easy passing multiple args from the make command (TODO left in the `generator.go`)
-- extract a common filter by name filter (TODO left in the `pkg/schemas/gen/main`)
 - describe and test all the template helpers (TODOs left in `templates_commons.go`)
 - test writing to file (TODO left in `util.go`)
-- use commons in the SDK generator

--- a/pkg/internal/genhelpers/README.md
+++ b/pkg/internal/genhelpers/README.md
@@ -75,6 +75,7 @@ To create a new generator:
 Functional improvements:
 - add a generic terraform schema reader, to allow later generation from schemas
 - handle the missing types (TODOs in [struct_details_extractor_test.go](./struct_details_extractor_test.go))
+- add support for custom command line flags
 
 Implementation improvements:
 - add acceptance test for a `testStruct` (the one from [struct_details_extractor_test.go](./struct_details_extractor_test.go)) for the whole generation flow

--- a/pkg/internal/genhelpers/README.md
+++ b/pkg/internal/genhelpers/README.md
@@ -61,7 +61,7 @@ To create a new generator:
    - second for a generation itself, in form of `generate-<makefile-command-part>`, e.g.
    ```makefile
    generate-snowflake-object-parameters-assertions:
-       go generate ./pkg/acceptance/bettertestspoc/assert/objectparametersassert/generate.g
+       go generate ./pkg/acceptance/bettertestspoc/assert/objectparametersassert/generate.go
    ```
 5. By default, generator support the following command line flags (invokable with e.g. `make generate-<makefile-command-part> SF_TF_GENERATOR_ARGS='<space-separated flags>'`)
    - `--dry-run` allowing to print the generated content to the command line instead of saving it to files

--- a/pkg/internal/genhelpers/README.md
+++ b/pkg/internal/genhelpers/README.md
@@ -28,8 +28,9 @@ Each generator workflow looks as follows:
 - The list of input objects is filtered using all defined filters (default and additional).
 - The list of generation parts is filtered using all defined filters (default and additional).
 - For each remaining object, each remaining generation part is run.
+- The generator returns to OS.
 
-##### Defining and running a new generator
+#### Defining and running a new generator
 
 Before proceeding with the following steps check [objectassert/gen](../../acceptance/bettertestspoc/assert/objectassert/gen) package for reference.
 
@@ -40,7 +41,7 @@ To create a new generator:
     - `model.go` containing the model definition and conversion
     - `templates.go` containing the templates definitions and helper functions 
 2. Create `generate.go` file on the same level as the `gen` package above with the following content only (in addition to the package name) `//go:generate go run ./gen/main/main.go $SF_TF_GENERATOR_ARGS`.
-3. In the `gen/main/main.go` create and run a new generator. This means:
+3. In the `gen/main/main.go` create and run a new generator. This means invoking the `genhelpers.NewGenerator` and:
    - providing the name and version for the generator
    - (currently optional) providing a short description and Makefile command part
    - providing an input definition for the source objects
@@ -50,6 +51,7 @@ To create a new generator:
    - providing method to translate enriched objects to the models used inside the templates
    - (optional) providing additional debug output you want to run for each of the objects
    - (optional) providing additional filters to limit the generation to only specific objects or generation parts
+   - ending with `RunAndHandleOsReturn()`
 4. Add two entries to our Makefile:
    - first for a cleanup, in form of `clean-<makefile-command-part>`, e.g.
    ```makefile
@@ -70,7 +72,7 @@ To create a new generator:
 
 ### Next steps
 
-##### Improvements
+#### Improvements
 
 Functional improvements:
 - add a generic terraform schema reader, to allow later generation from schemas

--- a/pkg/internal/genhelpers/flags.go
+++ b/pkg/internal/genhelpers/flags.go
@@ -1,0 +1,24 @@
+package genhelpers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// TODO [this PR]: add filter name to this type
+type filters []string
+
+func (f *filters) String() string {
+	return fmt.Sprint(*f)
+}
+
+func (f *filters) Set(value string) error {
+	if len(*f) > 0 {
+		return errors.New("filters already")
+	}
+	for _, fil := range strings.Split(value, ",") {
+		*f = append(*f, fil)
+	}
+	return nil
+}

--- a/pkg/internal/genhelpers/flags.go
+++ b/pkg/internal/genhelpers/flags.go
@@ -1,30 +1,40 @@
 package genhelpers
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
 
-// TODO [this PR]: add filter name to this type
-type filters []string
-
-func (f *filters) String() string {
-	return fmt.Sprint(*f)
+type filtersFlag struct {
+	name    string
+	filters []string
 }
 
-func (f *filters) Set(value string) error {
-	if len(*f) > 0 {
-		// TODO [this PR]: better error
-		return errors.New("filters already")
+func newFiltersFlag(name string) *filtersFlag {
+	return &filtersFlag{
+		name:    name,
+		filters: make([]string, 0),
+	}
+}
+
+func (f *filtersFlag) hasValues() bool {
+	return len(f.filters) > 0
+}
+
+func (f *filtersFlag) String() string {
+	return fmt.Sprintf("%s filter with values %s (len: %d)", f.name, f.filters, len(f.filters))
+}
+
+func (f *filtersFlag) Set(value string) error {
+	if len(f.filters) > 0 {
+		return fmt.Errorf("%s filters has been already initiated; use single attribute with comma-separated list", f.name)
 	}
 	value = strings.TrimSpace(value)
 	if value == "" {
-		// TODO [this PR]: return error here
-		return nil
+		return fmt.Errorf("%s filters cannot be initiated with an empty value; use single attribute with comma-separated list", f.name)
 	}
 	for _, fil := range strings.Split(value, ",") {
-		*f = append(*f, fil)
+		f.filters = append(f.filters, fil)
 	}
 	return nil
 }

--- a/pkg/internal/genhelpers/flags.go
+++ b/pkg/internal/genhelpers/flags.go
@@ -2,18 +2,24 @@ package genhelpers
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
 )
 
 type filtersFlag struct {
-	name    string
-	filters []string
+	name             string
+	filters          []string
+	availableOptions []string
 }
 
-func newFiltersFlag(name string) *filtersFlag {
+func newFiltersFlag(name string, availableOptions []string) *filtersFlag {
+	slices.Sort(availableOptions)
 	return &filtersFlag{
-		name:    name,
-		filters: make([]string, 0),
+		name:             name,
+		filters:          make([]string, 0),
+		availableOptions: availableOptions,
 	}
 }
 
@@ -21,7 +27,23 @@ func (f *filtersFlag) hasValues() bool {
 	return len(f.filters) > 0
 }
 
+func (f *filtersFlag) flagName() string {
+	return fmt.Sprintf("filter-%s", strings.ToLower(strings.ReplaceAll(f.name, " ", "-")))
+}
+
+func (f *filtersFlag) usage() string {
+	return fmt.Sprintf("generate only for the given %[1]s like `<name1>,<name2>,...`; available %[1]s:\n%s", f.name, formatAvailableOptions(f.availableOptions))
+}
+
+func formatAvailableOptions(options []string) string {
+	return strings.Join(collections.Map(options, func(s string) string { return " - " + s }), "\n") + "\n"
+}
+
 func (f *filtersFlag) String() string {
+	if len(f.filters) == 0 {
+		// this is considered a default value; the default usage prints: (default ...)
+		return fmt.Sprintf("is an empty list: all %s are used", f.name)
+	}
 	return fmt.Sprintf("%s filter with values %s (len: %d)", f.name, f.filters, len(f.filters))
 }
 

--- a/pkg/internal/genhelpers/flags.go
+++ b/pkg/internal/genhelpers/flags.go
@@ -15,7 +15,13 @@ func (f *filters) String() string {
 
 func (f *filters) Set(value string) error {
 	if len(*f) > 0 {
+		// TODO [this PR]: better error
 		return errors.New("filters already")
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		// TODO [this PR]: return error here
+		return nil
 	}
 	for _, fil := range strings.Split(value, ",") {
 		*f = append(*f, fil)

--- a/pkg/internal/genhelpers/generation_part_filters.go
+++ b/pkg/internal/genhelpers/generation_part_filters.go
@@ -15,3 +15,12 @@ func FilterGenerationPartByNameFromEnv[T ObjectNameProvider, M HasPreambleModel]
 	allowedObjectNames := strings.Split(allowedObjectNamesString, ",")
 	return slices.Contains(allowedObjectNames, part.GetName())
 }
+
+func filterGenerationPartByNameProvider[T ObjectNameProvider, M HasPreambleModel](allowedGenerationParts []string) func(part GenerationPart[T, M]) bool {
+	return func(part GenerationPart[T, M]) bool {
+		if len(allowedGenerationParts) == 0 {
+			return true
+		}
+		return slices.Contains(allowedGenerationParts, part.GetName())
+	}
+}

--- a/pkg/internal/genhelpers/generation_part_filters.go
+++ b/pkg/internal/genhelpers/generation_part_filters.go
@@ -1,20 +1,8 @@
 package genhelpers
 
 import (
-	"os"
 	"slices"
-	"strings"
 )
-
-// TODO [SNOW-2324252]: Consider extracting this as a command line param
-func FilterGenerationPartByNameFromEnv[T ObjectNameProvider, M HasPreambleModel](part GenerationPart[T, M]) bool {
-	allowedObjectNamesString := os.Getenv("SF_TF_GENERATOR_EXT_ALLOWED_GENERATION_PARTS_NAMES")
-	if allowedObjectNamesString == "" {
-		return true
-	}
-	allowedObjectNames := strings.Split(allowedObjectNamesString, ",")
-	return slices.Contains(allowedObjectNames, part.GetName())
-}
 
 func filterGenerationPartByNameProvider[T ObjectNameProvider, M HasPreambleModel](allowedGenerationParts []string) func(part GenerationPart[T, M]) bool {
 	return func(part GenerationPart[T, M]) bool {

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -182,6 +182,7 @@ usage: make generate-sdk SF_TF_GENERATOR_ARGS='<args>'
 }
 
 // TODO [SNOW-1501905]: temporary hacky solution to allow easy passing multiple args from the make command
+// TODO [this PR]: describe the reasoning
 func preprocessArgs() {
 	rest := os.Args[1:]
 	newArgs := []string{os.Args[0]}

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -114,6 +114,7 @@ func (g *Generator[T, M]) Run() error {
 	flag.Var(filterObjects, filterObjects.flagName(), filterObjects.usage())
 	flag.Var(filterParts, filterParts.flagName(), filterParts.usage())
 
+	// TODO [this PR]: generic description
 	flag.Usage = func() {
 		usage := `Generate SDK objects based on the SQL definitions provided.
 

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -204,11 +204,11 @@ usage: make [clean-%[2]s] generate-%[2]s SF_TF_GENERATOR_ARGS='<args>'
 // We would like to be able to alter the generator behavior based on the command line flags.
 // The easiest way to do this is to use a dedicated environment variable and pass it to every generator invocation, e.g.:
 //
-//	go:generate go run ./gen/main/main.go $SF_TF_GENERATOR_ARGS
+//	//go:generate go run ./gen/main/main.go $SF_TF_GENERATOR_ARGS
 //
 // The go:generate directive does only a simple string replacement without retokenization, so:
 //
-//	go:generate go run .cmd/mygen ${MYFLAGS}
+//	//go:generate go run .cmd/mygen ${MYFLAGS}
 //
 // is tokenized to:
 //

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -86,14 +86,12 @@ func (g *Generator[T, M]) WithAdditionalObjectsDebugLogs(objectLogsProvider func
 	return g
 }
 
-// TODO [this PR]: rename to AdditionalObjectFilter
-func (g *Generator[T, M]) WithObjectFilter(objectFilter func(T) bool) *Generator[T, M] {
+func (g *Generator[T, M]) WithAdditionalObjectFilter(objectFilter func(T) bool) *Generator[T, M] {
 	g.objectFilters = append(g.objectFilters, objectFilter)
 	return g
 }
 
-// TODO [this PR]: rename to AdditionalGenerationPartFilter
-func (g *Generator[T, M]) WithGenerationPartFilter(generationPartFilter func(GenerationPart[T, M]) bool) *Generator[T, M] {
+func (g *Generator[T, M]) WithAdditionalGenerationPartFilter(generationPartFilter func(GenerationPart[T, M]) bool) *Generator[T, M] {
 	g.generationPartFilters = append(g.generationPartFilters, generationPartFilter)
 	return g
 }

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -129,7 +129,7 @@ usage: make generate-sdk SF_TF_GENERATOR_ARGS='<args>'
 
 	if filterObjects.hasValues() {
 		fmt.Printf("Object filters present: %s\n", filterObjects)
-		g.objectFilters = append(g.objectFilters, filterObjectByNameProvider[T](filterParts.filters))
+		g.objectFilters = append(g.objectFilters, filterObjectByNameProvider[T](filterObjects.filters))
 	}
 	if filterParts.hasValues() {
 		fmt.Printf("Generation part filters present: %s\n", filterParts)

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -100,9 +100,22 @@ func (g *Generator[T, M]) Run() error {
 	file := os.Getenv("GOFILE")
 	fmt.Printf("Running generator on %s with args %#v\n", file, os.Args[1:])
 
+	var filterObjects filters
+	var filterParts filters
+
 	additionalLogs := flag.Bool("verbose", false, "print additional object debug logs")
 	dryRun := flag.Bool("dry-run", false, "generate to std out instead of saving")
+	flag.Var(&filterObjects, "filter-objects", "generate only objects")
+	flag.Var(&filterParts, "filter-parts", "generate only parts")
+
 	flag.Parse()
+
+	if len(filterObjects) > 0 {
+		g.objectFilters = append(g.objectFilters, filterObjectByNameProvider[T](filterObjects))
+	}
+	if len(filterParts) > 0 {
+		g.generationPartFilters = append(g.generationPartFilters, filterGenerationPartByNameProvider[T, M](filterParts))
+	}
 
 	objects := g.objectsProvider()
 	if len(g.objectFilters) > 0 {

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -17,6 +17,7 @@ type ObjectNameProvider interface {
 	ObjectName() string
 }
 
+// TODO [this PR]: allow printing allowed object filters and generation part filters
 type Generator[T ObjectNameProvider, M HasPreambleModel] struct {
 	objectsProvider func() []T
 	modelProvider   func(T, *PreambleModel) M
@@ -84,11 +85,13 @@ func (g *Generator[T, M]) WithAdditionalObjectsDebugLogs(objectLogsProvider func
 	return g
 }
 
+// TODO [this PR]: rename to AdditionalObjectFilter
 func (g *Generator[T, M]) WithObjectFilter(objectFilter func(T) bool) *Generator[T, M] {
 	g.objectFilters = append(g.objectFilters, objectFilter)
 	return g
 }
 
+// TODO [this PR]: rename to AdditionalGenerationPartFilter
 func (g *Generator[T, M]) WithGenerationPartFilter(generationPartFilter func(GenerationPart[T, M]) bool) *Generator[T, M] {
 	g.generationPartFilters = append(g.generationPartFilters, generationPartFilter)
 	return g

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -111,9 +111,11 @@ func (g *Generator[T, M]) Run() error {
 	flag.Parse()
 
 	if len(filterObjects) > 0 {
+		fmt.Printf("Object filters present: %s (len: %d)\n", filterObjects, len(filterObjects))
 		g.objectFilters = append(g.objectFilters, filterObjectByNameProvider[T](filterObjects))
 	}
 	if len(filterParts) > 0 {
+		fmt.Printf("Generation part filters present: %s (len: %d)\n", filterParts, len(filterParts))
 		g.generationPartFilters = append(g.generationPartFilters, filterGenerationPartByNameProvider[T, M](filterParts))
 	}
 

--- a/pkg/internal/genhelpers/generator.go
+++ b/pkg/internal/genhelpers/generator.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -109,21 +110,19 @@ func (g *Generator[T, M]) Run() error {
 	objects := g.objectsProvider()
 	parts := g.generationParts
 
-	allAvailableObjectNames := collections.Map(objects, func(o T) string {
-		return o.ObjectName()
-	})
-	allAvailableGenerationParts := collections.Map(parts, func(p GenerationPart[T, M]) string {
-		return p.GetName()
-	})
+	allAvailableObjectNames := collections.Map(objects, func(o T) string { return o.ObjectName() })
+	slices.Sort(allAvailableObjectNames)
+	allAvailableGenerationParts := collections.Map(parts, func(p GenerationPart[T, M]) string { return p.GetName() })
+	slices.Sort(allAvailableGenerationParts)
 
 	var filterObjects filters
 	var filterParts filters
 
+	// TODO [this PR]: improve descriptions
 	additionalLogs := flag.Bool("verbose", false, "print additional object debug logs")
 	dryRun := flag.Bool("dry-run", false, "generate to std out instead of saving")
-	// TODO [this PR]: better formatting; alphabetical
-	flag.Var(&filterObjects, "filter-objects", fmt.Sprintf("generate only objects; available objects:\n%s", strings.Join(collections.Map(allAvailableObjectNames, func(s string) string { return "   - " + s }), "\n")))
-	flag.Var(&filterParts, "filter-parts", fmt.Sprintf("generate only parts; available parts:\n%s", strings.Join(collections.Map(allAvailableGenerationParts, func(s string) string { return "   - " + s }), "\n")))
+	flag.Var(&filterObjects, "filter-objects", fmt.Sprintf("generate only objects; available objects:\n%s", formatAvailableOptions(allAvailableObjectNames)))
+	flag.Var(&filterParts, "filter-parts", fmt.Sprintf("generate only parts; available parts:\n%s", formatAvailableOptions(allAvailableGenerationParts)))
 
 	flag.Usage = func() {
 		usage := `Generate SDK objects based on the SQL definitions provided.
@@ -200,6 +199,10 @@ func preprocessArgs() {
 		newArgs = append(newArgs, strings.Split(a, " ")...)
 	}
 	os.Args = newArgs
+}
+
+func formatAvailableOptions(options []string) string {
+	return strings.Join(collections.Map(options, func(s string) string { return " - " + s }), "\n")
 }
 
 func (g *Generator[_, _]) RunAndHandleOsReturn() {

--- a/pkg/internal/genhelpers/imports_test.go
+++ b/pkg/internal/genhelpers/imports_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 // TODO [SNOW-2324252]: extract common setup, template for easier test writing
+// TODO [SNOW-2324252]: add test expecting error
 func Test_ExperimentWithImportsProcess(t *testing.T) {
 	t.Run("add standard imports", func(t *testing.T) {
 		src := []byte(`package somepackagename

--- a/pkg/internal/genhelpers/object_filters.go
+++ b/pkg/internal/genhelpers/object_filters.go
@@ -15,3 +15,12 @@ func FilterObjectByNameFromEnv[T ObjectNameProvider](object T) bool {
 	allowedObjectNames := strings.Split(allowedObjectNamesString, ",")
 	return slices.Contains(allowedObjectNames, object.ObjectName())
 }
+
+func filterObjectByNameProvider[T ObjectNameProvider](allowedObjectNames []string) func(object T) bool {
+	return func(object T) bool {
+		if len(allowedObjectNames) == 0 {
+			return true
+		}
+		return slices.Contains(allowedObjectNames, object.ObjectName())
+	}
+}

--- a/pkg/internal/genhelpers/object_filters.go
+++ b/pkg/internal/genhelpers/object_filters.go
@@ -1,20 +1,8 @@
 package genhelpers
 
 import (
-	"os"
 	"slices"
-	"strings"
 )
-
-// TODO [SNOW-2324252]: Consider extracting this as a command line param
-func FilterObjectByNameFromEnv[T ObjectNameProvider](object T) bool {
-	allowedObjectNamesString := os.Getenv("SF_TF_GENERATOR_EXT_ALLOWED_OBJECT_NAMES")
-	if allowedObjectNamesString == "" {
-		return true
-	}
-	allowedObjectNames := strings.Split(allowedObjectNamesString, ",")
-	return slices.Contains(allowedObjectNames, object.ObjectName())
-}
 
 func filterObjectByNameProvider[T ObjectNameProvider](allowedObjectNames []string) func(object T) bool {
 	return func(object T) bool {

--- a/pkg/schemas/gen/README.md
+++ b/pkg/schemas/gen/README.md
@@ -24,7 +24,12 @@ make clean-show-output-schemas generate-show-output-schemas
 
 To generate only chosen subset of all objects run:
 ```shell
-make clean-show-output-schemas generate-show-output-schemas SF_TF_GENERATOR_EXT_ALLOWED_OBJECT_NAMES="sdk.Warehouse,sdk.User"
+make clean-show-output-schemas generate-show-output-schemas SF_TF_GENERATOR_ARGS="--filter-object-names=sdk.Warehouse,sdk.User"
+```
+
+```shell
+# show usage
+make generate-show-output-schemas SF_TF_GENERATOR_ARGS='-h'
 ```
 
 ##### Supported types

--- a/pkg/schemas/gen/main/main.go
+++ b/pkg/schemas/gen/main/main.go
@@ -28,8 +28,6 @@ func main() {
 	).
 		WithAdditionalObjectsDebugLogs(printAllStructsFields).
 		WithAdditionalObjectsDebugLogs(printUniqueTypes).
-		// TODO [this PR]: remove this filter from here
-		WithObjectFilter(genhelpers.FilterObjectByNameFromEnv[genhelpers.StructDetails]).
 		RunAndHandleOsReturn()
 }
 

--- a/pkg/schemas/gen/main/main.go
+++ b/pkg/schemas/gen/main/main.go
@@ -28,6 +28,7 @@ func main() {
 	).
 		WithAdditionalObjectsDebugLogs(printAllStructsFields).
 		WithAdditionalObjectsDebugLogs(printUniqueTypes).
+		// TODO [this PR]: remove this filter from here
 		WithObjectFilter(genhelpers.FilterObjectByNameFromEnv[genhelpers.StructDetails]).
 		RunAndHandleOsReturn()
 }

--- a/pkg/sdk/poc/generator/main/main.go
+++ b/pkg/sdk/poc/generator/main/main.go
@@ -29,6 +29,8 @@ func main() {
 		WithGenerationPart("impl", filenameForPart("impl"), []*template.Template{genhelpers.PreambleTemplate, generator.ImplementationTemplate}).
 		WithGenerationPart("unit_tests", testFilenameForPart(""), []*template.Template{genhelpers.PreambleTemplate, generator.UnitTestsTemplate}).
 		WithGenerationPart("validations", filenameForPart("validations"), []*template.Template{genhelpers.PreambleTemplate, generator.ValidationsTemplate}).
+		WithDescription("Generate SDK objects based on the SQL definitions provided.").
+		WithMakefileCommandPart("sdk").
 		RunAndHandleOsReturn()
 }
 

--- a/pkg/sdk/poc/generator/main/main.go
+++ b/pkg/sdk/poc/generator/main/main.go
@@ -29,9 +29,6 @@ func main() {
 		WithGenerationPart("impl", filenameForPart("impl"), []*template.Template{genhelpers.PreambleTemplate, generator.ImplementationTemplate}).
 		WithGenerationPart("unit_tests", testFilenameForPart(""), []*template.Template{genhelpers.PreambleTemplate, generator.UnitTestsTemplate}).
 		WithGenerationPart("validations", filenameForPart("validations"), []*template.Template{genhelpers.PreambleTemplate, generator.ValidationsTemplate}).
-		// TODO [this PR]: remove these filter from here
-		WithObjectFilter(genhelpers.FilterObjectByNameFromEnv[*generator.Interface]).
-		WithGenerationPartFilter(genhelpers.FilterGenerationPartByNameFromEnv[*generator.Interface, *generator.Interface]).
 		RunAndHandleOsReturn()
 }
 

--- a/pkg/sdk/poc/generator/main/main.go
+++ b/pkg/sdk/poc/generator/main/main.go
@@ -29,6 +29,7 @@ func main() {
 		WithGenerationPart("impl", filenameForPart("impl"), []*template.Template{genhelpers.PreambleTemplate, generator.ImplementationTemplate}).
 		WithGenerationPart("unit_tests", testFilenameForPart(""), []*template.Template{genhelpers.PreambleTemplate, generator.UnitTestsTemplate}).
 		WithGenerationPart("validations", filenameForPart("validations"), []*template.Template{genhelpers.PreambleTemplate, generator.ValidationsTemplate}).
+		// TODO [this PR]: remove these filter from here
 		WithObjectFilter(genhelpers.FilterObjectByNameFromEnv[*generator.Interface]).
 		WithGenerationPartFilter(genhelpers.FilterGenerationPartByNameFromEnv[*generator.Interface, *generator.Interface]).
 		RunAndHandleOsReturn()

--- a/pkg/sdk/poc/internal/rework/README.md
+++ b/pkg/sdk/poc/internal/rework/README.md
@@ -24,13 +24,13 @@ make clean-sdk generate-sdk
 ```
 ```shell
 # generate all objects and chosen files only
-make clean-sdk generate-sdk SF_TF_GENERATOR_EXT_ALLOWED_GENERATION_PARTS_NAMES="default,dto,validations"
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-parts=default,dto,validations'
 ```
 ```shell
 # generate chosen objects only and all files
-make clean-sdk generate-sdk SF_TF_GENERATOR_EXT_ALLOWED_OBJECT_NAMES="Sequences"
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-objects=Sequences'
 ```
 ```shell
 # generate chosen objects and chosen files only
-make clean-sdk generate-sdk SF_TF_GENERATOR_EXT_ALLOWED_GENERATION_PARTS_NAMES="default,impl" SF_TF_GENERATOR_EXT_ALLOWED_OBJECT_NAMES="Streamlits"
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-parts=default,impl --filter-objects=Streamlits'
 ```

--- a/pkg/sdk/poc/internal/rework/README.md
+++ b/pkg/sdk/poc/internal/rework/README.md
@@ -34,3 +34,7 @@ make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-objects=Sequences'
 # generate chosen objects and chosen files only
 make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-parts=default,impl --filter-objects=Streamlits'
 ```
+```shell
+# show usage
+make generate-sdk SF_TF_GENERATOR_ARGS='-h'
+```

--- a/pkg/sdk/poc/internal/rework/README.md
+++ b/pkg/sdk/poc/internal/rework/README.md
@@ -24,15 +24,15 @@ make clean-sdk generate-sdk
 ```
 ```shell
 # generate all objects and chosen files only
-make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-parts=default,dto,validations'
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=default,dto,validations'
 ```
 ```shell
 # generate chosen objects only and all files
-make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-objects=Sequences'
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-object-names=Sequences'
 ```
 ```shell
 # generate chosen objects and chosen files only
-make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-parts=default,impl --filter-objects=Streamlits'
+make clean-sdk generate-sdk SF_TF_GENERATOR_ARGS='--filter-generation-part-names=default,impl --filter-object-names=Streamlits'
 ```
 ```shell
 # show usage


### PR DESCRIPTION
Continuation for: https://github.com/snowflakedb/terraform-provider-snowflake/pull/4049

Add common filtering flags to each generator:
- Add new custom flag for filters handling
- Replace the previous filters using environment variables to the ones using command line flag input
- Add description and makefile part to generator common
- Allow printing help for generator
- List all possible values for filters as part of the usage (example below)
- Update generator commons README
- Explain the args preprocessing
- Add missing TODO
- Update show schema generator readme

Example usage for the reworked SDK generator:
```
Generate SDK objects based on the SQL definitions provided.

usage: make [clean-sdk] generate-sdk SF_TF_GENERATOR_ARGS='<args>'

  -dry-run
        generate to std out instead of saving
  -filter-generation-part-names <name1>,<name2>,...
        generate only for the given generation part names like <name1>,<name2>,...; available generation part names:
         - default
         - dto
         - dto_builders
         - impl
         - unit_tests
         - validations
         (default is an empty list: all generation part names are used)
  -filter-object-names <name1>,<name2>,...
        generate only for the given object names like <name1>,<name2>,...; available object names:
         - Sequences
         - Streamlits
         (default is an empty list: all object names are used)
  -verbose
        print additional object debug logs

```