### PR TITLE
chore: Set dependabot target branch to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,15 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: daily
+    target-branch: "dev"
   - package-ecosystem: gomod
     directory: /tools
     open-pull-requests-limit: 3
     schedule:
       interval: weekly
+    target-branch: "dev"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    target-branch: "dev"


### PR DESCRIPTION
Set dependabot target branch to dev instead of the default one.

## References
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#target-branch-
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs#targeting-pull-requests-against-a-non-default-branch
