### PR TITLE
feat: Add support for AWS_SQS inbound notification integrations

### DIFF
--- a/docs/resources/notification_integration.md
+++ b/docs/resources/notification_integration.md
@@ -50,14 +50,14 @@ resource "snowflake_notification_integration" "integration" {
 ### Required
 
 - `name` (String)
-- `notification_provider` (String) The third-party cloud message queuing service (supported values: AZURE_STORAGE_QUEUE, AWS_SNS, GCP_PUBSUB; AWS_SQS is deprecated and will be removed in the future provider versions)
+- `notification_provider` (String) The third-party cloud message queuing service (supported values: AZURE_STORAGE_QUEUE, AWS_SQS, AWS_SNS, GCP_PUBSUB)
 
 ### Optional
 
 - `aws_sns_role_arn` (String) AWS IAM role ARN for notification integration to assume. Required for AWS_SNS provider
 - `aws_sns_topic_arn` (String) AWS SNS Topic ARN for notification integration to connect to. Required for AWS_SNS provider.
-- `aws_sqs_arn` (String, Deprecated) AWS SQS queue ARN for notification integration to connect to
-- `aws_sqs_role_arn` (String, Deprecated) AWS IAM role ARN for notification integration to assume
+- `aws_sqs_arn` (String) AWS SQS queue ARN for inbound notification integration (BYOQ - Bring Your Own Queue). Required for AWS_SQS provider.
+- `aws_sqs_role_arn` (String, Deprecated) AWS IAM role ARN for notification integration to assume (deprecated - not used for inbound AWS_SQS integrations)
 - `azure_storage_queue_primary_uri` (String) The queue ID for the Azure Queue Storage queue created for Event Grid notifications. Required for AZURE_STORAGE_QUEUE provider
 - `azure_tenant_id` (String) The ID of the Azure Active Directory tenant used for identity management. Required for AZURE_STORAGE_QUEUE provider
 - `comment` (String) A comment for the integration
@@ -72,8 +72,8 @@ resource "snowflake_notification_integration" "integration" {
 
 - `aws_sns_external_id` (String) The external ID that Snowflake will use when assuming the AWS role
 - `aws_sns_iam_user_arn` (String) The Snowflake user that will attempt to assume the AWS role.
-- `aws_sqs_external_id` (String, Deprecated) The external ID that Snowflake will use when assuming the AWS role
-- `aws_sqs_iam_user_arn` (String, Deprecated) The Snowflake user that will attempt to assume the AWS role.
+- `aws_sqs_external_id` (String) The external ID that Snowflake will use when assuming the AWS role
+- `aws_sqs_iam_user_arn` (String) The Snowflake user that will attempt to assume the AWS role.
 - `created_on` (String) Date and time when the notification integration was created.
 - `fully_qualified_name` (String) Fully qualified name of the resource. For more information, see [object name resolution](https://docs.snowflake.com/en/sql-reference/name-resolution).
 - `gcp_pubsub_service_account` (String) The GCP service account identifier that Snowflake will use when assuming the GCP role

--- a/pkg/resources/notification_integration_acceptance_test.go
+++ b/pkg/resources/notification_integration_acceptance_test.go
@@ -1,0 +1,64 @@
+//go:build non_account_level_tests
+
+package resources_test
+
+import (
+	"fmt"
+	"testing"
+
+	acc "github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+func TestAcc_NotificationIntegration_AWS_SQS(t *testing.T) {
+	// TODO [SNOW-1017580]: Use real SQS queue ARN from test environment
+	sqsArn := "arn:aws:sqs:us-east-2:123456789012:test-queue"
+	name := acc.TestClient().Ids.Alpha()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acc.TestAccProtoV6ProviderFactories,
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		PreCheck: func() { acc.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			// Create AWS_SQS notification integration
+			{
+				Config: awsSqsNotificationIntegrationConfig(name, sqsArn, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "name", name),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "notification_provider", "AWS_SQS"),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "aws_sqs_arn", sqsArn),
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "enabled", "true"),
+					resource.TestCheckResourceAttrSet("snowflake_notification_integration.test", "aws_sqs_iam_user_arn"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "snowflake_notification_integration.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update enabled
+			{
+				Config: awsSqsNotificationIntegrationConfig(name, sqsArn, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("snowflake_notification_integration.test", "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func awsSqsNotificationIntegrationConfig(name string, sqsArn string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "snowflake_notification_integration" "test" {
+  name                  = "%s"
+  notification_provider = "AWS_SQS"
+  aws_sqs_arn           = "%s"
+  enabled               = %t
+  comment               = "Terraform acceptance test for AWS_SQS"
+}
+`, name, sqsArn, enabled)
+}

--- a/pkg/sdk/notification_integrations_dto_builders_gen.go
+++ b/pkg/sdk/notification_integrations_dto_builders_gen.go
@@ -57,6 +57,11 @@ func (s *AutomatedDataLoadsParamsRequest) WithAzureAutoParams(azureAutoParams Az
 	return s
 }
 
+func (s *AutomatedDataLoadsParamsRequest) WithAmazonAutoParams(amazonAutoParams AmazonAutoParamsRequest) *AutomatedDataLoadsParamsRequest {
+	s.AmazonAutoParams = &amazonAutoParams
+	return s
+}
+
 func NewGoogleAutoParamsRequest(
 	gcpPubsubSubscriptionName string,
 ) *GoogleAutoParamsRequest {
@@ -72,6 +77,14 @@ func NewAzureAutoParamsRequest(
 	s := AzureAutoParamsRequest{}
 	s.AzureStorageQueuePrimaryUri = azureStorageQueuePrimaryUri
 	s.AzureTenantId = azureTenantId
+	return &s
+}
+
+func NewAmazonAutoParamsRequest(
+	awsSqsArn string,
+) *AmazonAutoParamsRequest {
+	s := AmazonAutoParamsRequest{}
+	s.AwsSqsArn = awsSqsArn
 	return &s
 }
 

--- a/pkg/sdk/notification_integrations_dto_gen.go
+++ b/pkg/sdk/notification_integrations_dto_gen.go
@@ -24,6 +24,7 @@ type CreateNotificationIntegrationRequest struct {
 type AutomatedDataLoadsParamsRequest struct {
 	GoogleAutoParams *GoogleAutoParamsRequest
 	AzureAutoParams  *AzureAutoParamsRequest
+	AmazonAutoParams *AmazonAutoParamsRequest
 }
 
 type GoogleAutoParamsRequest struct {
@@ -33,6 +34,10 @@ type GoogleAutoParamsRequest struct {
 type AzureAutoParamsRequest struct {
 	AzureStorageQueuePrimaryUri string // required
 	AzureTenantId               string // required
+}
+
+type AmazonAutoParamsRequest struct {
+	AwsSqsArn string // required
 }
 
 type PushNotificationParamsRequest struct {

--- a/pkg/sdk/notification_integrations_gen.go
+++ b/pkg/sdk/notification_integrations_gen.go
@@ -41,6 +41,7 @@ type AutomatedDataLoadsParams struct {
 	notificationType string            `ddl:"static" sql:"TYPE = QUEUE"`
 	GoogleAutoParams *GoogleAutoParams `ddl:"keyword"`
 	AzureAutoParams  *AzureAutoParams  `ddl:"keyword"`
+	AmazonAutoParams *AmazonAutoParams `ddl:"keyword"`
 }
 
 type GoogleAutoParams struct {
@@ -52,6 +53,12 @@ type AzureAutoParams struct {
 	notificationProvider        string `ddl:"static" sql:"NOTIFICATION_PROVIDER = AZURE_STORAGE_QUEUE"`
 	AzureStorageQueuePrimaryUri string `ddl:"parameter,single_quotes" sql:"AZURE_STORAGE_QUEUE_PRIMARY_URI"`
 	AzureTenantId               string `ddl:"parameter,single_quotes" sql:"AZURE_TENANT_ID"`
+}
+
+type AmazonAutoParams struct {
+	notificationProvider string `ddl:"static" sql:"NOTIFICATION_PROVIDER = AWS_SQS"`
+	direction            string `ddl:"static" sql:"DIRECTION = INBOUND"`
+	AwsSqsArn            string `ddl:"parameter,single_quotes" sql:"AWS_SQS_ARN"`
 }
 
 type PushNotificationParams struct {


### PR DESCRIPTION
# Add support for AWS_SQS inbound notification integrations

**Closes #4491**

## Summary

This PR restores support for **AWS_SQS inbound notification integrations** for Snowpipe automated data loads, implementing the BYOQ (Bring Your Own Queue) pattern that matches Azure Storage Queue and GCP Pub/Sub functionality.

## Background

AWS_SQS was previously deprecated in the provider, but Snowflake actually supports AWS_SQS for **inbound** notification integrations (customer-managed SQS queues), similar to how Azure and GCP work. This PR adds back the functionality with proper implementation.

## ⚠️ Important Context - This is an Existing Snowflake Feature

**This PR implements provider support for a feature that is already implemented and working in Snowflake.**

### Snowflake Implementation Status
- **Backend Implementation**: Already merged (Snowflake internal PR #367029)
- **Feature Name**: "Snowpipe multiple and custom SQS queues support"
- **Design Doc**: Internal Snowflake design document by Yang Wang (Feb 5, 2026)
- **First Customer**: Snowflake's internal O11y team migrating Snowhouse pipes to BYOQ

### Why This Provider Update Is Needed
1. **Feature is live in Snowflake** - The SQL syntax works and is in production
2. **Provider is the blocker** - Terraform/Pulumi providers haven't been updated to support it
3. **Internal teams blocked** - O11y team (and potentially external customers) cannot use IaC to manage these integrations
4. **Manually tested** - SQL has been verified working in Snowflake:
   ```sql
   CREATE NOTIFICATION INTEGRATION test_sqs
     ENABLED = TRUE
     TYPE = QUEUE
     NOTIFICATION_PROVIDER = AWS_SQS
     DIRECTION = INBOUND
     AWS_SQS_ARN = 'arn:aws:sqs:...'
   ```

### References
- Snowflake backend PR: `snowflake-eng/snowflake#367029`
- Internal use case: O11y team Snowhouse migration
- Related infrastructure PR: `snowflakedb/k8s-pulumi-app-resources#16171`

## Internal Snowflake Documentation

According to internal Snowflake documentation, the correct syntax for AWS_SQS inbound notification integrations is:

```sql
CREATE [ OR REPLACE ] NOTIFICATION INTEGRATION [ IF NOT EXISTS ] <name>
  ENABLED = { TRUE | FALSE }
  TYPE = QUEUE
  NOTIFICATION_PROVIDER = AWS_SQS
  DIRECTION = INBOUND
  AWS_SQS_ARN = '<queue_arn>'
  [ USE_PRIVATELINK_ENDPOINT = { TRUE | FALSE } ]
  [ COMMENT = '<string_literal>' ]
```

This has been tested and verified to work in Snowflake.

## Changes Made

### SDK Changes (`pkg/sdk/`)

1. **notification_integrations_gen.go**:
   - Added `AmazonAutoParams` to `AutomatedDataLoadsParams` struct
   - Added `AmazonAutoParams` struct definition with AWS_SQS_ARN and DIRECTION=INBOUND

2. **notification_integrations_dto_gen.go**:
   - Added `AmazonAutoParams` to `AutomatedDataLoadsParamsRequest`
   - Added `AmazonAutoParamsRequest` struct

3. **notification_integrations_dto_builders_gen.go**:
   - Added `WithAmazonAutoParams()` method
   - Added `NewAmazonAutoParamsRequest()` constructor

### Resource Changes (`pkg/resources/`)

4. **notification_integration.go**:
   - Added `case "AWS_SQS"` in `CreateNotificationIntegration()` function
   - Added `case "AWS_SQS_ARN"` in `ReadNotificationIntegration()` function
   - Updated `SF_AWS_IAM_USER_ARN` handling to distinguish between SNS and SQS
   - Added `case "AWS_SQS"` in `UpdateNotificationIntegration()` function
   - Removed deprecation warnings from `aws_sqs_arn` and `aws_sqs_iam_user_arn` fields
   - Updated schema descriptions to clarify AWS_SQS is for inbound/BYOQ
   - Removed TODO comment about removing SQS entirely

## Example Usage

```hcl
resource "snowflake_notification_integration" "sqs_integration" {
  name                  = "MY_SQS_INTEGRATION"
  enabled               = true
  notification_provider = "AWS_SQS"
  aws_sqs_arn          = "arn:aws:sqs:us-west-2:123456789012:my-queue"
  comment              = "Notification integration for customer-managed SQS queue"
}
```

## Computed Outputs

After creation, the integration exposes:
- `aws_sqs_iam_user_arn` - The Snowflake-generated IAM user ARN that needs to be granted access to your SQS queue

## Why This Is Needed

1. **Consistency**: Azure and GCP already support BYOQ via notification integrations. AWS should too.
2. **Isolation**: Customer-managed queues provide better workload isolation vs shared Snowflake-managed queues
3. **Scalability**: Dedicated queues per team/workload prevent hotspots
4. **Control**: Customers can monitor, audit, and manage their own SQS queues

## Testing

- ✅ Provider builds successfully
- ✅ Manual SQL testing confirms Snowflake accepts this syntax
- ✅ Used in production for Snowflake internal o11y infrastructure
- ✅ Validated against internal Snowflake design documentation
(https://github.com/snowflakedb/terraform-provider-snowflake/pull/4490#issuecomment-3954416201)

## Breaking Changes

None. This is purely additive functionality.

## Related Issues

Closes #4491