### PR TITLE
Trust Center [1/4] SDK interface, DTOs, and implementation

### DIFF
--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -83,6 +83,7 @@ type Client struct {
 	Tables                       Tables
 	Tags                         Tags
 	Tasks                        Tasks
+	TrustCenter                  TrustCenter
 	Users                        Users
 	UserProgrammaticAccessTokens UserProgrammaticAccessTokens
 	Views                        Views
@@ -219,6 +220,7 @@ func (c *Client) initialize() {
 	c.Tables = &tables{client: c}
 	c.Tags = &tags{client: c}
 	c.Tasks = &tasks{client: c}
+	c.TrustCenter = &trustCenter{client: c}
 	c.Users = &users{client: c}
 	c.UserProgrammaticAccessTokens = &userProgrammaticAccessTokens{client: c}
 	c.Views = &views{client: c}

--- a/pkg/sdk/trust_center.go
+++ b/pkg/sdk/trust_center.go
@@ -1,0 +1,26 @@
+package sdk
+
+import "context"
+
+// TrustCenter provides an interface for managing Trust Center scanner configurations.
+// Trust Center uses stored procedures rather than DDL commands, so this implementation
+// builds SQL CALL statements directly.
+type TrustCenter interface {
+	// Scanner Package Configuration (Account Level)
+	SetPackageConfiguration(ctx context.Context, req *SetPackageConfigurationRequest) error
+	UnsetPackageConfiguration(ctx context.Context, req *UnsetPackageConfigurationRequest) error
+	ShowScannerPackages(ctx context.Context, req *ShowScannerPackagesRequest) ([]ScannerPackage, error)
+	ShowScannerPackageByID(ctx context.Context, id string) (*ScannerPackage, error)
+
+	// Scanner Configuration (Account Level)
+	SetScannerConfiguration(ctx context.Context, req *SetScannerConfigurationRequest) error
+	UnsetScannerConfiguration(ctx context.Context, req *UnsetScannerConfigurationRequest) error
+	ShowScanners(ctx context.Context, req *ShowScannersRequest) ([]Scanner, error)
+	ShowScannerByID(ctx context.Context, packageId, scannerId string) (*Scanner, error)
+}
+
+var _ TrustCenter = (*trustCenter)(nil)
+
+type trustCenter struct {
+	client *Client
+}

--- a/pkg/sdk/trust_center_dto.go
+++ b/pkg/sdk/trust_center_dto.go
@@ -1,0 +1,233 @@
+package sdk
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ConfigurationLevel represents the type of configuration being set.
+type TrustCenterConfigurationLevel string
+
+const (
+	TrustCenterConfigurationLevelEnabled      TrustCenterConfigurationLevel = "ENABLED"
+	TrustCenterConfigurationLevelSchedule     TrustCenterConfigurationLevel = "SCHEDULE"
+	TrustCenterConfigurationLevelNotification TrustCenterConfigurationLevel = "NOTIFICATION"
+)
+
+// ScannerPackage represents a Trust Center scanner package from the scanner_packages view.
+type ScannerPackage struct {
+	Name                  string
+	Id                    string
+	Description           string
+	DefaultSchedule       string
+	State                 string // "TRUE" or "FALSE"
+	Schedule              string
+	Notification          string // JSON string
+	Provider              string
+	LastEnabledTimestamp  *string
+	LastDisabledTimestamp *string
+}
+
+// scannerPackageRow is the database row structure for scanner packages.
+type scannerPackageRow struct {
+	Name                  sql.NullString `db:"NAME"`
+	Id                    sql.NullString `db:"ID"`
+	Description           sql.NullString `db:"DESCRIPTION"`
+	DefaultSchedule       sql.NullString `db:"DEFAULT_SCHEDULE"`
+	State                 sql.NullString `db:"STATE"`
+	Schedule              sql.NullString `db:"SCHEDULE"`
+	Notification          sql.NullString `db:"NOTIFICATION"`
+	Provider              sql.NullString `db:"PROVIDER"`
+	LastEnabledTimestamp  sql.NullString `db:"LAST_ENABLED_TIMESTAMP"`
+	LastDisabledTimestamp sql.NullString `db:"LAST_DISABLED_TIMESTAMP"`
+}
+
+func (r *scannerPackageRow) convert() *ScannerPackage {
+	pkg := &ScannerPackage{
+		Name:            r.Name.String,
+		Id:              r.Id.String,
+		Description:     r.Description.String,
+		DefaultSchedule: r.DefaultSchedule.String,
+		State:           r.State.String,
+		Schedule:        r.Schedule.String,
+		Notification:    r.Notification.String,
+		Provider:        r.Provider.String,
+	}
+	if r.LastEnabledTimestamp.Valid {
+		pkg.LastEnabledTimestamp = &r.LastEnabledTimestamp.String
+	}
+	if r.LastDisabledTimestamp.Valid {
+		pkg.LastDisabledTimestamp = &r.LastDisabledTimestamp.String
+	}
+	return pkg
+}
+
+// Scanner represents a Trust Center scanner from the scanners view.
+type Scanner struct {
+	Name              string
+	Id                string
+	ShortDescription  string
+	Description       string
+	ScannerPackageId  string
+	State             string
+	Schedule          string
+	Notification      string // JSON string
+	LastScanTimestamp *string
+}
+
+// scannerRow is the database row structure for scanners.
+type scannerRow struct {
+	Name              sql.NullString `db:"NAME"`
+	Id                sql.NullString `db:"ID"`
+	ShortDescription  sql.NullString `db:"SHORT_DESCRIPTION"`
+	Description       sql.NullString `db:"DESCRIPTION"`
+	ScannerPackageId  sql.NullString `db:"SCANNER_PACKAGE_ID"`
+	State             sql.NullString `db:"STATE"`
+	Schedule          sql.NullString `db:"SCHEDULE"`
+	Notification      sql.NullString `db:"NOTIFICATION"`
+	LastScanTimestamp sql.NullString `db:"LAST_SCAN_TIMESTAMP"`
+}
+
+func (r *scannerRow) convert() *Scanner {
+	scanner := &Scanner{
+		Name:             r.Name.String,
+		Id:               r.Id.String,
+		ShortDescription: r.ShortDescription.String,
+		Description:      r.Description.String,
+		ScannerPackageId: r.ScannerPackageId.String,
+		State:            r.State.String,
+		Schedule:         r.Schedule.String,
+		Notification:     r.Notification.String,
+	}
+	if r.LastScanTimestamp.Valid {
+		scanner.LastScanTimestamp = &r.LastScanTimestamp.String
+	}
+	return scanner
+}
+
+// NotificationConfiguration represents the notification settings for a scanner or package.
+type NotificationConfiguration struct {
+	NotifyAdmins      *bool    `json:"NOTIFY_ADMINS,omitempty"`
+	SeverityThreshold *string  `json:"SEVERITY_THRESHOLD,omitempty"`
+	Users             []string `json:"USERS,omitempty"`
+}
+
+// ToJSON converts the notification configuration to a JSON string for use in SQL calls.
+func (n *NotificationConfiguration) ToJSON() (string, error) {
+	if n == nil {
+		return "", nil
+	}
+	bytes, err := json.Marshal(n)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+// ParseNotificationConfiguration parses a JSON string into a NotificationConfiguration.
+func ParseNotificationConfiguration(jsonStr string) (*NotificationConfiguration, error) {
+	if jsonStr == "" {
+		return nil, nil
+	}
+	var config NotificationConfiguration
+	err := json.Unmarshal([]byte(jsonStr), &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// SetPackageConfigurationRequest is the request for setting scanner package configuration.
+type SetPackageConfigurationRequest struct {
+	ScannerPackageId string
+	Enabled          *bool
+	Schedule         *string
+	Notification     *NotificationConfiguration
+}
+
+// UnsetPackageConfigurationRequest is the request for unsetting scanner package configuration.
+type UnsetPackageConfigurationRequest struct {
+	ScannerPackageId   string
+	UnsetEnabled       bool
+	UnsetSchedule      bool
+	UnsetNotification  bool
+}
+
+// ShowScannerPackagesRequest is the request for showing scanner packages.
+type ShowScannerPackagesRequest struct {
+	Like *string
+}
+
+// SetScannerConfigurationRequest is the request for setting individual scanner configuration.
+type SetScannerConfigurationRequest struct {
+	ScannerPackageId string
+	ScannerId        string
+	Enabled          *bool
+	Schedule         *string
+	Notification     *NotificationConfiguration
+}
+
+// UnsetScannerConfigurationRequest is the request for unsetting individual scanner configuration.
+type UnsetScannerConfigurationRequest struct {
+	ScannerPackageId  string
+	ScannerId         string
+	UnsetEnabled      bool
+	UnsetSchedule     bool
+	UnsetNotification bool
+}
+
+// ShowScannersRequest is the request for showing scanners.
+type ShowScannersRequest struct {
+	ScannerPackageId *string
+	Like             *string
+}
+
+// TrustCenterScannerPackageId represents the identifier for a scanner package resource.
+type TrustCenterScannerPackageId struct {
+	Source           string // e.g., "SNOWFLAKE" for first-party
+	ScannerPackageId string
+}
+
+// String returns the string representation of the scanner package ID using the | delimiter.
+func (id TrustCenterScannerPackageId) String() string {
+	return id.Source + "|" + id.ScannerPackageId
+}
+
+// ParseTrustCenterScannerPackageId parses a string into a TrustCenterScannerPackageId.
+func ParseTrustCenterScannerPackageId(s string) (TrustCenterScannerPackageId, error) {
+	parts := strings.Split(s, "|")
+	if len(parts) != 2 {
+		return TrustCenterScannerPackageId{}, fmt.Errorf("expected 2 parts for TrustCenterScannerPackageId, got %d from: %s", len(parts), s)
+	}
+	return TrustCenterScannerPackageId{
+		Source:           parts[0],
+		ScannerPackageId: parts[1],
+	}, nil
+}
+
+// TrustCenterScannerId represents the identifier for a scanner resource.
+type TrustCenterScannerId struct {
+	Source           string
+	ScannerPackageId string
+	ScannerId        string
+}
+
+// String returns the string representation of the scanner ID using the | delimiter.
+func (id TrustCenterScannerId) String() string {
+	return id.Source + "|" + id.ScannerPackageId + "|" + id.ScannerId
+}
+
+// ParseTrustCenterScannerId parses a string into a TrustCenterScannerId.
+func ParseTrustCenterScannerId(s string) (TrustCenterScannerId, error) {
+	parts := strings.Split(s, "|")
+	if len(parts) != 3 {
+		return TrustCenterScannerId{}, fmt.Errorf("expected 3 parts for TrustCenterScannerId, got %d from: %s", len(parts), s)
+	}
+	return TrustCenterScannerId{
+		Source:           parts[0],
+		ScannerPackageId: parts[1],
+		ScannerId:        parts[2],
+	}, nil
+}

--- a/pkg/sdk/trust_center_impl.go
+++ b/pkg/sdk/trust_center_impl.go
@@ -1,0 +1,288 @@
+package sdk
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/internal/collections"
+)
+
+// SetPackageConfiguration sets configuration for a scanner package.
+// It calls the trust_center.set_configuration stored procedure.
+func (tc *trustCenter) SetPackageConfiguration(ctx context.Context, req *SetPackageConfigurationRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ScannerPackageId == "" {
+		return fmt.Errorf("scanner_package_id is required")
+	}
+
+	// Set ENABLED if specified
+	if req.Enabled != nil {
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelEnabled, *req.Enabled)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set ENABLED configuration: %w", err)
+		}
+	}
+
+	// Set SCHEDULE if specified
+	if req.Schedule != nil {
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelSchedule, *req.Schedule)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set SCHEDULE configuration: %w", err)
+		}
+	}
+
+	// Set NOTIFICATION if specified
+	if req.Notification != nil {
+		notificationJSON, err := req.Notification.ToJSON()
+		if err != nil {
+			return fmt.Errorf("failed to serialize notification configuration: %w", err)
+		}
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelNotification, notificationJSON)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set NOTIFICATION configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// UnsetPackageConfiguration unsets configuration for a scanner package.
+func (tc *trustCenter) UnsetPackageConfiguration(ctx context.Context, req *UnsetPackageConfigurationRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ScannerPackageId == "" {
+		return fmt.Errorf("scanner_package_id is required")
+	}
+
+	// Unset ENABLED
+	if req.UnsetEnabled {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelEnabled)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset ENABLED configuration: %w", err)
+		}
+	}
+
+	// Unset SCHEDULE
+	if req.UnsetSchedule {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelSchedule)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset SCHEDULE configuration: %w", err)
+		}
+	}
+
+	// Unset NOTIFICATION
+	if req.UnsetNotification {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, "", TrustCenterConfigurationLevelNotification)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset NOTIFICATION configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ShowScannerPackages lists scanner packages from the trust_center.scanner_packages view.
+func (tc *trustCenter) ShowScannerPackages(ctx context.Context, req *ShowScannerPackagesRequest) ([]ScannerPackage, error) {
+	sql := "SELECT * FROM snowflake.trust_center.scanner_packages"
+	if req != nil && req.Like != nil && *req.Like != "" {
+		sql += fmt.Sprintf(" WHERE NAME LIKE '%s'", strings.ReplaceAll(*req.Like, "'", "''"))
+	}
+
+	var rows []scannerPackageRow
+	if err := tc.client.query(ctx, &rows, sql); err != nil {
+		return nil, fmt.Errorf("failed to query scanner packages: %w", err)
+	}
+
+	packages := make([]ScannerPackage, len(rows))
+	for i, row := range rows {
+		packages[i] = *row.convert()
+	}
+	return packages, nil
+}
+
+// ShowScannerPackageByID retrieves a single scanner package by ID.
+func (tc *trustCenter) ShowScannerPackageByID(ctx context.Context, id string) (*ScannerPackage, error) {
+	packages, err := tc.ShowScannerPackages(ctx, &ShowScannerPackagesRequest{Like: &id})
+	if err != nil {
+		return nil, err
+	}
+	return collections.FindFirst(packages, func(p ScannerPackage) bool { return p.Id == id })
+}
+
+// SetScannerConfiguration sets configuration for an individual scanner.
+func (tc *trustCenter) SetScannerConfiguration(ctx context.Context, req *SetScannerConfigurationRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ScannerPackageId == "" {
+		return fmt.Errorf("scanner_package_id is required")
+	}
+	if req.ScannerId == "" {
+		return fmt.Errorf("scanner_id is required")
+	}
+
+	// Set ENABLED if specified
+	if req.Enabled != nil {
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelEnabled, *req.Enabled)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set ENABLED configuration: %w", err)
+		}
+	}
+
+	// Set SCHEDULE if specified
+	if req.Schedule != nil {
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelSchedule, *req.Schedule)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set SCHEDULE configuration: %w", err)
+		}
+	}
+
+	// Set NOTIFICATION if specified
+	if req.Notification != nil {
+		notificationJSON, err := req.Notification.ToJSON()
+		if err != nil {
+			return fmt.Errorf("failed to serialize notification configuration: %w", err)
+		}
+		sql := tc.buildSetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelNotification, notificationJSON)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to set NOTIFICATION configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// UnsetScannerConfiguration unsets configuration for an individual scanner.
+func (tc *trustCenter) UnsetScannerConfiguration(ctx context.Context, req *UnsetScannerConfigurationRequest) error {
+	if req == nil {
+		return fmt.Errorf("request cannot be nil")
+	}
+	if req.ScannerPackageId == "" {
+		return fmt.Errorf("scanner_package_id is required")
+	}
+	if req.ScannerId == "" {
+		return fmt.Errorf("scanner_id is required")
+	}
+
+	// Unset ENABLED
+	if req.UnsetEnabled {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelEnabled)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset ENABLED configuration: %w", err)
+		}
+	}
+
+	// Unset SCHEDULE
+	if req.UnsetSchedule {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelSchedule)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset SCHEDULE configuration: %w", err)
+		}
+	}
+
+	// Unset NOTIFICATION
+	if req.UnsetNotification {
+		sql := tc.buildUnsetConfigurationSQL(req.ScannerPackageId, req.ScannerId, TrustCenterConfigurationLevelNotification)
+		if _, err := tc.client.exec(ctx, sql); err != nil {
+			return fmt.Errorf("failed to unset NOTIFICATION configuration: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// ShowScanners lists scanners from the trust_center.scanners view.
+func (tc *trustCenter) ShowScanners(ctx context.Context, req *ShowScannersRequest) ([]Scanner, error) {
+	sql := "SELECT * FROM snowflake.trust_center.scanners"
+
+	var conditions []string
+	if req != nil {
+		if req.ScannerPackageId != nil && *req.ScannerPackageId != "" {
+			conditions = append(conditions, fmt.Sprintf("SCANNER_PACKAGE_ID = '%s'", strings.ReplaceAll(*req.ScannerPackageId, "'", "''")))
+		}
+		if req.Like != nil && *req.Like != "" {
+			conditions = append(conditions, fmt.Sprintf("NAME LIKE '%s'", strings.ReplaceAll(*req.Like, "'", "''")))
+		}
+	}
+
+	if len(conditions) > 0 {
+		sql += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	var rows []scannerRow
+	if err := tc.client.query(ctx, &rows, sql); err != nil {
+		return nil, fmt.Errorf("failed to query scanners: %w", err)
+	}
+
+	scanners := make([]Scanner, len(rows))
+	for i, row := range rows {
+		scanners[i] = *row.convert()
+	}
+	return scanners, nil
+}
+
+// ShowScannerByID retrieves a single scanner by package ID and scanner ID.
+func (tc *trustCenter) ShowScannerByID(ctx context.Context, packageId, scannerId string) (*Scanner, error) {
+	scanners, err := tc.ShowScanners(ctx, &ShowScannersRequest{ScannerPackageId: &packageId})
+	if err != nil {
+		return nil, err
+	}
+	return collections.FindFirst(scanners, func(s Scanner) bool { return s.Id == scannerId })
+}
+
+// buildSetConfigurationSQL builds the SQL CALL statement for set_configuration.
+// Format: CALL snowflake.trust_center.set_configuration(
+//
+//	'<scanner_package_id>',
+//	[SCANNER_ID => '<scanner_id>',]
+//	CONFIGURATION_LEVEL => '<level>',
+//	VALUE => <value>
+//
+// )
+func (tc *trustCenter) buildSetConfigurationSQL(packageId, scannerId string, level TrustCenterConfigurationLevel, value interface{}) string {
+	var sb strings.Builder
+	sb.WriteString("CALL snowflake.trust_center.set_configuration(")
+	sb.WriteString(fmt.Sprintf("'%s'", strings.ReplaceAll(packageId, "'", "''")))
+
+	if scannerId != "" {
+		sb.WriteString(fmt.Sprintf(", SCANNER_ID => '%s'", strings.ReplaceAll(scannerId, "'", "''")))
+	}
+
+	sb.WriteString(fmt.Sprintf(", CONFIGURATION_LEVEL => '%s'", level))
+
+	switch v := value.(type) {
+	case bool:
+		sb.WriteString(fmt.Sprintf(", VALUE => %t", v))
+	case string:
+		if level == TrustCenterConfigurationLevelNotification {
+			// Notification is passed as PARSE_JSON
+			sb.WriteString(fmt.Sprintf(", VALUE => PARSE_JSON('%s')", strings.ReplaceAll(v, "'", "''")))
+		} else {
+			sb.WriteString(fmt.Sprintf(", VALUE => '%s'", strings.ReplaceAll(v, "'", "''")))
+		}
+	default:
+		sb.WriteString(fmt.Sprintf(", VALUE => '%v'", v))
+	}
+
+	sb.WriteString(")")
+	return sb.String()
+}
+
+// buildUnsetConfigurationSQL builds the SQL CALL statement for unset_configuration.
+func (tc *trustCenter) buildUnsetConfigurationSQL(packageId, scannerId string, level TrustCenterConfigurationLevel) string {
+	var sb strings.Builder
+	sb.WriteString("CALL snowflake.trust_center.unset_configuration(")
+	sb.WriteString(fmt.Sprintf("'%s'", strings.ReplaceAll(packageId, "'", "''")))
+
+	if scannerId != "" {
+		sb.WriteString(fmt.Sprintf(", SCANNER_ID => '%s'", strings.ReplaceAll(scannerId, "'", "''")))
+	}
+
+	sb.WriteString(fmt.Sprintf(", CONFIGURATION_LEVEL => '%s'", level))
+	sb.WriteString(")")
+	return sb.String()
+}

--- a/pkg/sdk/trust_center_impl.go
+++ b/pkg/sdk/trust_center_impl.go
@@ -89,7 +89,7 @@ func (tc *trustCenter) UnsetPackageConfiguration(ctx context.Context, req *Unset
 func (tc *trustCenter) ShowScannerPackages(ctx context.Context, req *ShowScannerPackagesRequest) ([]ScannerPackage, error) {
 	sql := "SELECT * FROM snowflake.trust_center.scanner_packages"
 	if req != nil && req.Like != nil && *req.Like != "" {
-		sql += fmt.Sprintf(" WHERE NAME LIKE '%s'", strings.ReplaceAll(*req.Like, "'", "''"))
+		sql += fmt.Sprintf(" WHERE NAME LIKE %s", escapeSnowflakeStringLiteral(*req.Like))
 	}
 
 	var rows []scannerPackageRow
@@ -202,10 +202,10 @@ func (tc *trustCenter) ShowScanners(ctx context.Context, req *ShowScannersReques
 	var conditions []string
 	if req != nil {
 		if req.ScannerPackageId != nil && *req.ScannerPackageId != "" {
-			conditions = append(conditions, fmt.Sprintf("SCANNER_PACKAGE_ID = '%s'", strings.ReplaceAll(*req.ScannerPackageId, "'", "''")))
+			conditions = append(conditions, fmt.Sprintf("SCANNER_PACKAGE_ID = %s", escapeSnowflakeStringLiteral(*req.ScannerPackageId)))
 		}
 		if req.Like != nil && *req.Like != "" {
-			conditions = append(conditions, fmt.Sprintf("NAME LIKE '%s'", strings.ReplaceAll(*req.Like, "'", "''")))
+			conditions = append(conditions, fmt.Sprintf("NAME LIKE %s", escapeSnowflakeStringLiteral(*req.Like)))
 		}
 	}
 
@@ -246,10 +246,10 @@ func (tc *trustCenter) ShowScannerByID(ctx context.Context, packageId, scannerId
 func (tc *trustCenter) buildSetConfigurationSQL(packageId, scannerId string, level TrustCenterConfigurationLevel, value interface{}) string {
 	var sb strings.Builder
 	sb.WriteString("CALL snowflake.trust_center.set_configuration(")
-	sb.WriteString(fmt.Sprintf("'%s'", strings.ReplaceAll(packageId, "'", "''")))
+	sb.WriteString(escapeSnowflakeStringLiteral(packageId))
 
 	if scannerId != "" {
-		sb.WriteString(fmt.Sprintf(", SCANNER_ID => '%s'", strings.ReplaceAll(scannerId, "'", "''")))
+		sb.WriteString(fmt.Sprintf(", SCANNER_ID => %s", escapeSnowflakeStringLiteral(scannerId)))
 	}
 
 	sb.WriteString(fmt.Sprintf(", CONFIGURATION_LEVEL => '%s'", level))
@@ -259,13 +259,12 @@ func (tc *trustCenter) buildSetConfigurationSQL(packageId, scannerId string, lev
 		sb.WriteString(fmt.Sprintf(", VALUE => %t", v))
 	case string:
 		if level == TrustCenterConfigurationLevelNotification {
-			// Notification is passed as PARSE_JSON
-			sb.WriteString(fmt.Sprintf(", VALUE => PARSE_JSON('%s')", strings.ReplaceAll(v, "'", "''")))
+			sb.WriteString(fmt.Sprintf(", VALUE => PARSE_JSON(%s)", escapeSnowflakeStringLiteral(v)))
 		} else {
-			sb.WriteString(fmt.Sprintf(", VALUE => '%s'", strings.ReplaceAll(v, "'", "''")))
+			sb.WriteString(fmt.Sprintf(", VALUE => %s", escapeSnowflakeStringLiteral(v)))
 		}
 	default:
-		sb.WriteString(fmt.Sprintf(", VALUE => '%v'", v))
+		sb.WriteString(fmt.Sprintf(", VALUE => %s", escapeSnowflakeStringLiteral(fmt.Sprintf("%v", v))))
 	}
 
 	sb.WriteString(")")
@@ -276,13 +275,19 @@ func (tc *trustCenter) buildSetConfigurationSQL(packageId, scannerId string, lev
 func (tc *trustCenter) buildUnsetConfigurationSQL(packageId, scannerId string, level TrustCenterConfigurationLevel) string {
 	var sb strings.Builder
 	sb.WriteString("CALL snowflake.trust_center.unset_configuration(")
-	sb.WriteString(fmt.Sprintf("'%s'", strings.ReplaceAll(packageId, "'", "''")))
+	sb.WriteString(escapeSnowflakeStringLiteral(packageId))
 
 	if scannerId != "" {
-		sb.WriteString(fmt.Sprintf(", SCANNER_ID => '%s'", strings.ReplaceAll(scannerId, "'", "''")))
+		sb.WriteString(fmt.Sprintf(", SCANNER_ID => %s", escapeSnowflakeStringLiteral(scannerId)))
 	}
 
 	sb.WriteString(fmt.Sprintf(", CONFIGURATION_LEVEL => '%s'", level))
 	sb.WriteString(")")
 	return sb.String()
+}
+
+// escapeSnowflakeStringLiteral escapes a string for safe inclusion as a
+// single-quoted SQL literal by doubling any embedded single quotes.
+func escapeSnowflakeStringLiteral(s string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''"))
 }

--- a/pkg/sdk/trust_center_test.go
+++ b/pkg/sdk/trust_center_test.go
@@ -1,0 +1,260 @@
+package sdk
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrustCenter_BuildSetConfigurationSQL(t *testing.T) {
+	tc := &trustCenter{}
+
+	t.Run("package level enabled", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelEnabled, true)
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'ENABLED', VALUE => true)", sql)
+	})
+
+	t.Run("package level disabled", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelEnabled, false)
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'ENABLED', VALUE => false)", sql)
+	})
+
+	t.Run("package level schedule", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelSchedule, "USING CRON 0 2 * * * UTC")
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'SCHEDULE', VALUE => 'USING CRON 0 2 * * * UTC')", sql)
+	})
+
+	t.Run("package level notification", func(t *testing.T) {
+		notification := `{"NOTIFY_ADMINS":true,"SEVERITY_THRESHOLD":"High"}`
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelNotification, notification)
+		assert.Equal(t, `CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'NOTIFICATION', VALUE => PARSE_JSON('{"NOTIFY_ADMINS":true,"SEVERITY_THRESHOLD":"High"}'))`, sql)
+	})
+
+	t.Run("scanner level enabled", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "MFA_CHECK", TrustCenterConfigurationLevelEnabled, true)
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', SCANNER_ID => 'MFA_CHECK', CONFIGURATION_LEVEL => 'ENABLED', VALUE => true)", sql)
+	})
+
+	t.Run("scanner level schedule", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("SECURITY_ESSENTIALS", "MFA_CHECK", TrustCenterConfigurationLevelSchedule, "USING CRON 0 0 * * * UTC")
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('SECURITY_ESSENTIALS', SCANNER_ID => 'MFA_CHECK', CONFIGURATION_LEVEL => 'SCHEDULE', VALUE => 'USING CRON 0 0 * * * UTC')", sql)
+	})
+
+	t.Run("escape single quotes in package id", func(t *testing.T) {
+		sql := tc.buildSetConfigurationSQL("PACKAGE'WITH'QUOTES", "", TrustCenterConfigurationLevelEnabled, true)
+		assert.Equal(t, "CALL snowflake.trust_center.set_configuration('PACKAGE''WITH''QUOTES', CONFIGURATION_LEVEL => 'ENABLED', VALUE => true)", sql)
+	})
+}
+
+func TestTrustCenter_BuildUnsetConfigurationSQL(t *testing.T) {
+	tc := &trustCenter{}
+
+	t.Run("package level enabled", func(t *testing.T) {
+		sql := tc.buildUnsetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelEnabled)
+		assert.Equal(t, "CALL snowflake.trust_center.unset_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'ENABLED')", sql)
+	})
+
+	t.Run("package level schedule", func(t *testing.T) {
+		sql := tc.buildUnsetConfigurationSQL("SECURITY_ESSENTIALS", "", TrustCenterConfigurationLevelSchedule)
+		assert.Equal(t, "CALL snowflake.trust_center.unset_configuration('SECURITY_ESSENTIALS', CONFIGURATION_LEVEL => 'SCHEDULE')", sql)
+	})
+
+	t.Run("scanner level enabled", func(t *testing.T) {
+		sql := tc.buildUnsetConfigurationSQL("SECURITY_ESSENTIALS", "MFA_CHECK", TrustCenterConfigurationLevelEnabled)
+		assert.Equal(t, "CALL snowflake.trust_center.unset_configuration('SECURITY_ESSENTIALS', SCANNER_ID => 'MFA_CHECK', CONFIGURATION_LEVEL => 'ENABLED')", sql)
+	})
+}
+
+func TestNotificationConfiguration_ToJSON(t *testing.T) {
+	t.Run("full configuration", func(t *testing.T) {
+		notifyAdmins := true
+		severity := "High"
+		config := &NotificationConfiguration{
+			NotifyAdmins:      &notifyAdmins,
+			SeverityThreshold: &severity,
+			Users:             []string{"USER1", "USER2"},
+		}
+		json, err := config.ToJSON()
+		require.NoError(t, err)
+		assert.Contains(t, json, `"NOTIFY_ADMINS":true`)
+		assert.Contains(t, json, `"SEVERITY_THRESHOLD":"High"`)
+		assert.Contains(t, json, `"USERS":["USER1","USER2"]`)
+	})
+
+	t.Run("partial configuration", func(t *testing.T) {
+		severity := "Critical"
+		config := &NotificationConfiguration{
+			SeverityThreshold: &severity,
+		}
+		json, err := config.ToJSON()
+		require.NoError(t, err)
+		assert.Contains(t, json, `"SEVERITY_THRESHOLD":"Critical"`)
+		assert.NotContains(t, json, "NOTIFY_ADMINS")
+		assert.NotContains(t, json, "USERS")
+	})
+
+	t.Run("nil configuration", func(t *testing.T) {
+		var config *NotificationConfiguration
+		json, err := config.ToJSON()
+		require.NoError(t, err)
+		assert.Equal(t, "", json)
+	})
+}
+
+func TestParseNotificationConfiguration(t *testing.T) {
+	t.Run("full configuration", func(t *testing.T) {
+		jsonStr := `{"NOTIFY_ADMINS":true,"SEVERITY_THRESHOLD":"High","USERS":["USER1","USER2"]}`
+		config, err := ParseNotificationConfiguration(jsonStr)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.True(t, *config.NotifyAdmins)
+		assert.Equal(t, "High", *config.SeverityThreshold)
+		assert.Equal(t, []string{"USER1", "USER2"}, config.Users)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		config, err := ParseNotificationConfiguration("")
+		require.NoError(t, err)
+		assert.Nil(t, config)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := ParseNotificationConfiguration("not valid json")
+		assert.Error(t, err)
+	})
+}
+
+func TestTrustCenterScannerPackageId_String(t *testing.T) {
+	id := TrustCenterScannerPackageId{
+		Source:           "SNOWFLAKE",
+		ScannerPackageId: "SECURITY_ESSENTIALS",
+	}
+	assert.Equal(t, "SNOWFLAKE|SECURITY_ESSENTIALS", id.String())
+}
+
+func TestTrustCenterScannerId_String(t *testing.T) {
+	id := TrustCenterScannerId{
+		Source:           "SNOWFLAKE",
+		ScannerPackageId: "SECURITY_ESSENTIALS",
+		ScannerId:        "MFA_CHECK",
+	}
+	assert.Equal(t, "SNOWFLAKE|SECURITY_ESSENTIALS|MFA_CHECK", id.String())
+}
+
+func TestParseTrustCenterScannerPackageId(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		id, err := ParseTrustCenterScannerPackageId("SNOWFLAKE|SECURITY_ESSENTIALS")
+		require.NoError(t, err)
+		assert.Equal(t, "SNOWFLAKE", id.Source)
+		assert.Equal(t, "SECURITY_ESSENTIALS", id.ScannerPackageId)
+	})
+
+	t.Run("wrong number of parts", func(t *testing.T) {
+		_, err := ParseTrustCenterScannerPackageId("SNOWFLAKE|SECURITY_ESSENTIALS|EXTRA")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 2 parts")
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, err := ParseTrustCenterScannerPackageId("")
+		assert.Error(t, err)
+	})
+}
+
+func TestParseTrustCenterScannerId(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		id, err := ParseTrustCenterScannerId("SNOWFLAKE|SECURITY_ESSENTIALS|MFA_CHECK")
+		require.NoError(t, err)
+		assert.Equal(t, "SNOWFLAKE", id.Source)
+		assert.Equal(t, "SECURITY_ESSENTIALS", id.ScannerPackageId)
+		assert.Equal(t, "MFA_CHECK", id.ScannerId)
+	})
+
+	t.Run("wrong number of parts", func(t *testing.T) {
+		_, err := ParseTrustCenterScannerId("SNOWFLAKE|SECURITY_ESSENTIALS")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 3 parts")
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		_, err := ParseTrustCenterScannerId("")
+		assert.Error(t, err)
+	})
+}
+
+func TestScannerPackageRow_Convert(t *testing.T) {
+	t.Run("with all fields", func(t *testing.T) {
+		row := &scannerPackageRow{
+			Name:                  toNullString("Security Essentials"),
+			Id:                    toNullString("SECURITY_ESSENTIALS"),
+			Description:           toNullString("Core security scanners"),
+			DefaultSchedule:       toNullString("USING CRON 0 0 * * * UTC"),
+			State:                 toNullString("TRUE"),
+			Schedule:              toNullString("USING CRON 0 2 * * * UTC"),
+			Notification:          toNullString(`{"NOTIFY_ADMINS":true}`),
+			Provider:              toNullString("Snowflake"),
+			LastEnabledTimestamp:  toNullString("2024-01-01T00:00:00Z"),
+			LastDisabledTimestamp: toNullString("2024-01-02T00:00:00Z"),
+		}
+		pkg := row.convert()
+		assert.Equal(t, "Security Essentials", pkg.Name)
+		assert.Equal(t, "SECURITY_ESSENTIALS", pkg.Id)
+		assert.Equal(t, "Core security scanners", pkg.Description)
+		assert.Equal(t, "TRUE", pkg.State)
+		assert.NotNil(t, pkg.LastEnabledTimestamp)
+		assert.NotNil(t, pkg.LastDisabledTimestamp)
+	})
+
+	t.Run("with null timestamps", func(t *testing.T) {
+		row := &scannerPackageRow{
+			Name:  toNullString("Test Package"),
+			Id:    toNullString("TEST_PACKAGE"),
+			State: toNullString("FALSE"),
+		}
+		pkg := row.convert()
+		assert.Nil(t, pkg.LastEnabledTimestamp)
+		assert.Nil(t, pkg.LastDisabledTimestamp)
+	})
+}
+
+func TestScannerRow_Convert(t *testing.T) {
+	t.Run("with all fields", func(t *testing.T) {
+		row := &scannerRow{
+			Name:              toNullString("MFA Check"),
+			Id:                toNullString("MFA_CHECK"),
+			ShortDescription:  toNullString("Checks MFA status"),
+			Description:       toNullString("Detailed MFA check description"),
+			ScannerPackageId:  toNullString("SECURITY_ESSENTIALS"),
+			State:             toNullString("TRUE"),
+			Schedule:          toNullString("USING CRON 0 0 * * * UTC"),
+			Notification:      toNullString(`{"NOTIFY_ADMINS":true}`),
+			LastScanTimestamp: toNullString("2024-01-01T00:00:00Z"),
+		}
+		scanner := row.convert()
+		assert.Equal(t, "MFA Check", scanner.Name)
+		assert.Equal(t, "MFA_CHECK", scanner.Id)
+		assert.Equal(t, "SECURITY_ESSENTIALS", scanner.ScannerPackageId)
+		assert.NotNil(t, scanner.LastScanTimestamp)
+	})
+
+	t.Run("with null timestamp", func(t *testing.T) {
+		row := &scannerRow{
+			Name:             toNullString("Test Scanner"),
+			Id:               toNullString("TEST_SCANNER"),
+			ScannerPackageId: toNullString("TEST_PACKAGE"),
+			State:            toNullString("FALSE"),
+		}
+		scanner := row.convert()
+		assert.Nil(t, scanner.LastScanTimestamp)
+	})
+}
+
+// Helper function to create sql.NullString
+func toNullString(s string) (ns sql.NullString) {
+	if s == "" {
+		return
+	}
+	return sql.NullString{String: s, Valid: true}
+}


### PR DESCRIPTION
Add SDK layer for Trust Center scanner package and scanner management using stored procedures (CALL) and views rather than DDL. Includes:

- TrustCenter interface with Set/Unset/Show operations
- Scanner and ScannerPackage DTOs with row conversion
- TrustCenterScannerPackageId and TrustCenterScannerId types using | delimiter (matching provider convention)
- Parse functions for both ID types
- Unit tests for SQL generation, ID serialization, and parsing

<!-- Feel free to delete comments as you fill this in -->

<!-- summary of changes -->

## Test Plan
<!-- detail ways in which this PR has been tested or needs to be tested -->
* [ ] acceptance tests
<!-- add more below if you think they are relevant -->
* [ ] …

## References
<!-- issues documentation links, etc  -->

* 