### PR TITLE
fix: (SNOW-3953574) Handle unprefixed database role grantee names in SHOW GRANTS (BCR-2371)

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -220,6 +220,26 @@ Now, a column type that cannot be parsed no longer fails the whole describe call
 
 References: [#5090](https://github.com/snowflakedb/terraform-provider-snowflake/issues/5090)
 
+### *(bug fix)* Fixed handling of unprefixed database role grantee names in `SHOW GRANTS` (2026_06 bundle / BCR-2371)
+
+Previously, when a database role was granted to another database role, the provider expected the `SHOW GRANTS OF DATABASE ROLE` output to return the grantee database role as a fully qualified name (`<database>.<database_role>`). The 2026_06 bundle (BCR-2371) changes this output so that the grantee database role is returned without the database prefix (just `<database_role>`). With the bundle enabled, the provider could not parse the grantee name, so the Read operation of the `snowflake_grant_database_role` resource failed to find the grant and marked the resource as deleted. `terraform plan` then showed a permanent diff recreating the grant, and `terraform apply` returned an error like
+
+```
+│ Error: Provider produced inconsistent result after apply
+│
+│ When applying changes to snowflake_grant_database_role.example, provider "provider[\"registry.terraform.io/snowflakedb/snowflake\"]" produced an unexpected new value: Root object was present, but now absent.
+│
+│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
+```
+
+Importing such a resource failed for the same reason (`Cannot import non-existent remote object`).
+
+In this release, the grantee database role name is normalized to a fully qualified identifier regardless of whether the bundle is enabled: when the database prefix is missing, it is reconstructed from the database of the queried database role (a database role can only be granted to another database role in the same database). The `snowflake_grant_database_role` resource is no longer recreated on every plan and can be imported again.
+
+No changes in configuration are required.
+
+References: [Snowflake BCR Bundles](https://docs.snowflake.com/en/release-notes/behavior-changes).
+
 ## v2.18.x ➞ v2.19.0
 
 ### *(improvement)* Rework of `snowflake_account_authentication_policy_attachment` and `snowflake_user_authentication_policy_attachment`

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -405,11 +405,20 @@ func (v *grants) Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, err
 			}
 			resultList[i].GranteeName = NewAccountObjectIdentifier(granteeName)
 		} else if !slices.Contains([]ObjectType{ObjectTypeRole, ObjectTypeShare, ObjectTypeUser, ObjectTypeApplication}, grant.GrantedTo) {
-			id, err := ParseDatabaseObjectIdentifier(granteeNameRaw)
+			// Before BCR-2371 the grantee (another database role) is fully qualified (<database>.<database_role>); after, only <database_role>.
+			// A database role can only be granted within the same database, so reconstruct the missing prefix from the queried role.
+			granteeNameParts, err := ParseIdentifierString(granteeNameRaw)
 			if err != nil {
 				return nil, err
 			}
-			resultList[i].GranteeName = id
+			switch len(granteeNameParts) {
+			case 1:
+				resultList[i].GranteeName = NewDatabaseObjectIdentifier(opts.Of.DatabaseRole.DatabaseName(), granteeNameParts[0])
+			case 2:
+				resultList[i].GranteeName = NewDatabaseObjectIdentifier(granteeNameParts[0], granteeNameParts[1])
+			default:
+				return nil, fmt.Errorf("unexpected number of parts %d in database role grantee name %s, expected 1 (<database_role>) or 2 (<database>.<database_role>)", len(granteeNameParts), granteeNameRaw)
+			}
 		} else if grant.GrantedTo == ObjectTypeUser {
 			resultList[i].GranteeName = NewAccountObjectIdentifier(strings.TrimPrefix(granteeNameRaw, "USER$"))
 		} else {

--- a/pkg/sdk/grants_impl.go
+++ b/pkg/sdk/grants_impl.go
@@ -407,17 +407,12 @@ func (v *grants) Show(ctx context.Context, opts *ShowGrantOptions) ([]Grant, err
 		} else if !slices.Contains([]ObjectType{ObjectTypeRole, ObjectTypeShare, ObjectTypeUser, ObjectTypeApplication}, grant.GrantedTo) {
 			// Before BCR-2371 the grantee (another database role) is fully qualified (<database>.<database_role>); after, only <database_role>.
 			// A database role can only be granted within the same database, so reconstruct the missing prefix from the queried role.
-			granteeNameParts, err := ParseIdentifierString(granteeNameRaw)
-			if err != nil {
+			if id, err := ParseDatabaseObjectIdentifier(granteeNameRaw); err == nil {
+				resultList[i].GranteeName = id
+			} else if id, err := ParseAccountObjectIdentifier(granteeNameRaw); err == nil {
+				resultList[i].GranteeName = NewDatabaseObjectIdentifier(opts.Of.DatabaseRole.DatabaseName(), id.Name())
+			} else {
 				return nil, err
-			}
-			switch len(granteeNameParts) {
-			case 1:
-				resultList[i].GranteeName = NewDatabaseObjectIdentifier(opts.Of.DatabaseRole.DatabaseName(), granteeNameParts[0])
-			case 2:
-				resultList[i].GranteeName = NewDatabaseObjectIdentifier(granteeNameParts[0], granteeNameParts[1])
-			default:
-				return nil, fmt.Errorf("unexpected number of parts %d in database role grantee name %s, expected 1 (<database_role>) or 2 (<database>.<database_role>)", len(granteeNameParts), granteeNameRaw)
 			}
 		} else if grant.GrantedTo == ObjectTypeUser {
 			resultList[i].GranteeName = NewAccountObjectIdentifier(strings.TrimPrefix(granteeNameRaw, "USER$"))

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -2519,11 +2519,14 @@ func TestInt_ShowGrants(t *testing.T) {
 		// grantee database role without the database prefix. The grantee identifier must stay fully
 		// qualified regardless of whether the bundle is enabled, otherwise the grant_database_role
 		// resource cannot match the grant on read/import and is perpetually recreated.
+		// A database role can only be granted to another database role in the same database, so the child
+		// and parent roles are created in the same database (CreateDatabaseRole uses the same one).
+		// Note: on a bundle-off account this passes with or without the fix (the grantee is returned
+		// prefixed); the authoritative regression that toggles the 2026_06 bundle is the account-level
+		// acceptance test TestAcc_GrantDatabaseRole_bcr2026_06_databaseRoleGrantee.
 		childRole, childRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
 		t.Cleanup(childRoleCleanup)
 
-		// A database role can only be granted to another database role in the same database, so the
-		// parent role is created in the same database as the child (CreateDatabaseRole uses the same one).
 		parentRole, parentRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
 		t.Cleanup(parentRoleCleanup)
 

--- a/pkg/sdk/testint/grants_integration_test.go
+++ b/pkg/sdk/testint/grants_integration_test.go
@@ -2514,6 +2514,33 @@ func TestInt_ShowGrants(t *testing.T) {
 		assert.Equal(t, testClientHelper().Ids.SnowflakeApplicationId().Name(), grants[0].GranteeName.Name())
 	})
 
+	t.Run("grantee name of a database role granted to another database role is fully qualified", func(t *testing.T) {
+		// Regression test for the 2026_06 bundle (BCR-2371): SHOW GRANTS OF DATABASE ROLE returns the
+		// grantee database role without the database prefix. The grantee identifier must stay fully
+		// qualified regardless of whether the bundle is enabled, otherwise the grant_database_role
+		// resource cannot match the grant on read/import and is perpetually recreated.
+		childRole, childRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+		t.Cleanup(childRoleCleanup)
+
+		// A database role can only be granted to another database role in the same database, so the
+		// parent role is created in the same database as the child (CreateDatabaseRole uses the same one).
+		parentRole, parentRoleCleanup := testClientHelper().DatabaseRole.CreateDatabaseRole(t)
+		t.Cleanup(parentRoleCleanup)
+
+		err := client.DatabaseRoles.Grant(ctx, sdk.NewGrantDatabaseRoleRequest(childRole.ID()).WithDatabaseRole(parentRole.ID()))
+		require.NoError(t, err)
+
+		grants, err := client.Grants.Show(ctx, &sdk.ShowGrantOptions{
+			Of: &sdk.ShowGrantsOf{
+				DatabaseRole: childRole.ID(),
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, grants, 1)
+		assert.Equal(t, sdk.ObjectTypeDatabaseRole, grants[0].GrantedTo)
+		assert.Equal(t, parentRole.ID().FullyQualifiedName(), grants[0].GranteeName.FullyQualifiedName())
+	})
+
 	t.Run("show inherited grants in database", func(t *testing.T) {
 		database, databaseCleanup := testClientHelper().Database.CreateDatabase(t)
 		t.Cleanup(databaseCleanup)

--- a/pkg/testacc/resource_grant_database_role_account_level_acceptance_test.go
+++ b/pkg/testacc/resource_grant_database_role_account_level_acceptance_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/assert"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/model"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/bettertestspoc/config/providermodel"
+	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/acceptance/testprofiles"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/helpers"
 	"github.com/Snowflake-Labs/terraform-provider-snowflake/pkg/sdk"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -51,6 +55,70 @@ func TestAcc_GrantDatabaseRole_Issue_3629(t *testing.T) {
 				Check: assertThat(
 					t,
 					assert.Check(resource.TestCheckResourceAttr("snowflake_grant_database_role.test", "id", helpers.EncodeResourceIdentifier(databaseRole.ID().FullyQualifiedName(), sdk.ObjectTypeRole.String(), accountRole.ID().FullyQualifiedName()))),
+				),
+			},
+		},
+	})
+}
+
+func TestAcc_GrantDatabaseRole_bcr2026_06_databaseRoleGrantee(t *testing.T) {
+	// Regression test for SNOW-3953574 (PR https://github.com/snowflakedb/terraform-provider-snowflake/pull/5099):
+	// the 2026_06 bundle (BCR-2371) makes SHOW GRANTS OF DATABASE ROLE return the grantee database role
+	// without the database prefix. Before the fix, ReadGrantDatabaseRole could not parse the unprefixed
+	// grantee, cleared the id, and the resource was perpetually recreated (apply failed with an
+	// "inconsistent result after apply" error). The fixed provider reconstructs the fully qualified
+	// grantee and matches the grant again.
+	// TODO(SNOW-3953574): skip or remove this test once the 2026_06 bundle is enforced and can no longer be disabled.
+
+	// A database role can only be granted to another database role in the same database, and
+	// CreateDatabaseRole creates both in the same database. Run on the secondary account because toggling
+	// a behavior change bundle is account-wide.
+	childRole, childRoleCleanup := secondaryTestClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(childRoleCleanup)
+
+	parentRole, parentRoleCleanup := secondaryTestClient().DatabaseRole.CreateDatabaseRole(t)
+	t.Cleanup(parentRoleCleanup)
+
+	providerModel := providermodel.SnowflakeProvider().WithProfile(testprofiles.Secondary)
+	grantModel := model.GrantDatabaseRole("test", childRole.ID().FullyQualifiedName()).
+		WithParentDatabaseRoleName(parentRole.ID().FullyQualifiedName())
+	expectedId := helpers.EncodeResourceIdentifier(childRole.ID().FullyQualifiedName(), sdk.ObjectTypeDatabaseRole.String(), parentRole.ID().FullyQualifiedName())
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.RequireAbove(tfversion.Version1_5_0),
+		},
+		Steps: []resource.TestStep{
+			// Latest released provider, bundle disabled: the grantee is returned fully qualified and parses fine.
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.19.0"),
+				PreConfig: func() {
+					secondaryTestClient().BcrBundles.DisableBcrBundle(t, "2026_06")
+				},
+				Config: config.FromModels(t, providerModel, grantModel),
+				Check: assertThat(
+					t,
+					assert.Check(resource.TestCheckResourceAttr(grantModel.ResourceReference(), "id", expectedId)),
+				),
+			},
+			// Same released provider, bundle enabled: the unprefixed grantee can no longer be parsed, so Read
+			// clears the id and apply fails with an inconsistent-result error.
+			{
+				ExternalProviders: ExternalProviderWithExactVersion("2.19.0"),
+				PreConfig: func() {
+					secondaryTestClient().BcrBundles.EnableBcrBundle(t, "2026_06")
+				},
+				Config:      config.FromModels(t, providerModel, grantModel),
+				ExpectError: regexp.MustCompile("Provider produced inconsistent result after apply"),
+			},
+			// Fixed provider, bundle still enabled: the grantee is normalized back to a fully qualified
+			// identifier, the grant matches on Read, and the resource is stable.
+			{
+				ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
+				Config:                   config.FromModels(t, providerModel, grantModel),
+				Check: assertThat(
+					t,
+					assert.Check(resource.TestCheckResourceAttr(grantModel.ResourceReference(), "id", expectedId)),
 				),
 			},
 		},


### PR DESCRIPTION
### Issue
SNOW-3953574 (customer complaint)


The 2026_06 bundle (BCR-2371) changes `SHOW GRANTS OF DATABASE ROLE` so a database role granted to another database role is returned without the database prefix (PARENT_DR) instead of fully qualified (MYDB.PARENT_DR).

`ParseDatabaseObjectIdentifier` requires two parts and errored on the unprefixed name, aborting the whole `Show()` call. 
`ReadGrantDatabaseRole` then cleared the resource ID, causing a perpetual re-create, "Provider produced inconsistent result after apply" errors, and failed imports.

The grantee name is now normalized to a fully qualified identifier in both bundle states: when the prefix is absent it is reconstructed from the queried role's database (a database role can only be granted to another database role in the same database), keeping the grantee stable and importable whether or not the bundle is enabled.

Adds an SDK integration test and a MIGRATION_GUIDE.md entry.

### References
* BCR-2371 - SHOW GRANTS output consistency improvement - https://docs.snowflake.com/en/release-notes/bcr-bundles/2026_06/bcr-2371