### PR TITLE
fix: invalidate no longer cancels an in-flight load for its key

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -54,11 +54,11 @@ declared.
 
 If you would like to specify an empty list, please use `none = true` instead.
 
-### *(bug fix)* Concurrent `Invalidate` could turn an unrelated in-flight read into an error
+### *(bug fix)* Concurrent `Invalidate` could turn an unrelated in-flight read into an error (experimental `SHOW` caching only)
 
-Several resources (e.g. `snowflake_grant_ownership`, `snowflake_grant_privileges_to_account_role`) share a per-plan cache for expensive `SHOW`-based reads, keyed so that multiple resource instances resolving to the same `SHOW` statement collapse into a single lookup. When one resource instance mutated the underlying object and invalidated that cache key while another instance's read for the same key was still in flight, the invalidation canceled the shared in-flight read for every caller, not just the one that triggered it. Unrelated resource instances could then fail their `Read` with a spurious `context canceled` error during a plan/apply with enough parallelism.
+This only affects configurations that opt into the `GRANT_ACCOUNT_ROLE_SHOW_CACHING`, `ACCOUNT_ROLE_SHOW_CACHING`, or `GRANTS_SHOW_CACHING` experimental features via `enabled_experimental_features`. With one of these enabled, several resources (e.g. `snowflake_grant_ownership`, `snowflake_grant_privileges_to_account_role`) share a per-plan cache for the relevant `SHOW`-based reads, keyed so that multiple resource instances resolving to the same `SHOW` statement collapse into a single lookup. When one resource instance mutated the underlying object and invalidated that cache key while another instance's read for the same key was still in flight, the invalidation canceled the shared in-flight read for every caller, not just the one that triggered it. Unrelated resource instances could then fail their `Read` with a spurious `context canceled` error during a plan/apply with enough parallelism.
 
-Invalidation no longer cancels an in-flight read. A read that races an invalidation for its key simply isn't cached, so the next read for that key performs a fresh lookup instead of reusing stale data.
+Invalidation no longer cancels an in-flight read. A read that races an invalidation for its key now completes normally and returns whatever it was already fetching (which may still reflect pre-mutation state), instead of erroring out. That result is just not written back into the cache, so it does not linger: the next read for that key performs its own fresh lookup rather than reusing it.
 
 ### *(bug fix)* `snowflake_storage_lifecycle_policy`: perpetual in-place update of `describe_output`
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -54,6 +54,12 @@ declared.
 
 If you would like to specify an empty list, please use `none = true` instead.
 
+### *(bug fix)* Concurrent `Invalidate` could turn an unrelated in-flight read into an error
+
+Several resources (e.g. `snowflake_grant_ownership`, `snowflake_grant_privileges_to_account_role`) share a per-plan cache for expensive `SHOW`-based reads, keyed so that multiple resource instances resolving to the same `SHOW` statement collapse into a single lookup. When one resource instance mutated the underlying object and invalidated that cache key while another instance's read for the same key was still in flight, the invalidation canceled the shared in-flight read for every caller, not just the one that triggered it. Unrelated resource instances could then fail their `Read` with a spurious `context canceled` error during a plan/apply with enough parallelism.
+
+Invalidation no longer cancels an in-flight read. A read that races an invalidation for its key simply isn't cached, so the next read for that key performs a fresh lookup instead of reusing stale data.
+
 ### *(bug fix)* `snowflake_storage_lifecycle_policy`: perpetual in-place update of `describe_output`
 
 `snowflake_storage_lifecycle_policy` could produce a non-empty plan on every run even when the configuration was unchanged. The planned change was an in-place update of the computed `describe_output` attribute:

--- a/pkg/internal/provider/cache.go
+++ b/pkg/internal/provider/cache.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"golang.org/x/sync/singleflight"
@@ -30,29 +31,34 @@ import (
 // the data map — it is never held across loadFn, so a slow lookup for one key cannot serialize
 // lookups for other keys (which is exactly what Terraform's parallel resource reads rely on).
 //
+// Invalidate never cancels a load already in flight for its key: that load may be shared (via
+// singleflight) with callers unrelated to whatever mutation triggered the invalidation, and turning
+// their read into an error would be worse than letting it complete normally. Instead, each key has a
+// generation counter that Invalidate bumps. The generation is folded into the singleflight key, so a
+// concurrent Invalidate simply causes the in-flight load's result to go uncached (a subsequent
+// GetOrLoad reloads under the new generation) rather than forcing it to fail.
+//
 // Cache is generic over the cached value type so it can be reused for other lookups in the future.
 type Cache[T any] struct {
-	mu      sync.RWMutex
-	data    map[string]T
-	group   singleflight.Group
-	cancels map[string]context.CancelFunc
+	mu         sync.RWMutex
+	data       map[string]T
+	generation map[string]uint64
+	group      singleflight.Group
 }
 
 // NewCache returns an initialized, empty cache.
 func NewCache[T any]() *Cache[T] {
-	return &Cache[T]{data: make(map[string]T), cancels: make(map[string]context.CancelFunc)}
+	return &Cache[T]{data: make(map[string]T), generation: make(map[string]uint64)}
 }
 
-// GetOrLoad returns the cached value for key. On a cache miss it calls loadFn,
-// stores the result, and returns it. Concurrent misses on the same key are collapsed
-// into a single loadFn call whose result is shared by all callers. If loadFn returns an
+// GetOrLoad returns the cached value for key. On a cache miss it calls loadFn, stores the
+// result, and returns it. Concurrent misses on the same key and generation (see Invalidate) are
+// collapsed into a single loadFn call whose result is shared by all callers. If loadFn returns an
 // error the result is not cached and the error is propagated to the caller.
 //
-// ctx is the caller's Terraform-provided context (so resource Timeouts and plan cancellation
-// propagate into the Snowflake call on a cache miss). Because concurrent misses on the same key
-// are collapsed into a single loadFn call via singleflight, only the ctx of whichever caller
-// triggers the load actually governs it; a later caller joining an in-flight load is not able to
-// cancel it via its own ctx, only via Invalidate.
+// ctx is passed to loadFn unchanged: canceling it (e.g. a resource Timeout or plan cancellation)
+// cancels the load for every caller currently sharing it, exactly as it would for a direct call
+// to loadFn.
 func (c *Cache[T]) GetOrLoad(ctx context.Context, key string, loadFn func(ctx context.Context) (T, error)) (T, error) {
 	// Fast path: warm cache hit, read lock only. Skips singleflight entirely.
 	c.mu.RLock()
@@ -60,12 +66,15 @@ func (c *Cache[T]) GetOrLoad(ctx context.Context, key string, loadFn func(ctx co
 		c.mu.RUnlock()
 		return v, nil
 	}
+	gen := c.generation[key]
 	c.mu.RUnlock()
 
-	// Slow path: deduplicate concurrent misses per key. singleflight.Group.Do serializes
-	// only callers sharing the same key; different keys run concurrently. We do NOT hold
-	// c.mu across loadFn.
-	v, err, _ := c.group.Do(key, func() (any, error) {
+	// Folding the generation into the singleflight key means an Invalidate landing between
+	// here and the Do call below starts a fresh singleflight group for key, rather than
+	// joining (or having to cancel) whatever's already in flight for it.
+	sfKey := fmt.Sprintf("%d:%s", gen, key)
+
+	v, err, _ := c.group.Do(sfKey, func() (any, error) {
 		// Re-check under the read lock: another caller may have populated the entry
 		// after our fast-path miss but before this call began executing.
 		c.mu.RLock()
@@ -75,29 +84,18 @@ func (c *Cache[T]) GetOrLoad(ctx context.Context, key string, loadFn func(ctx co
 		}
 		c.mu.RUnlock()
 
-		loadCtx, cancel := context.WithCancel(ctx)
-		c.mu.Lock()
-		c.cancels[key] = cancel
-		c.mu.Unlock()
-		defer func() {
-			c.mu.Lock()
-			delete(c.cancels, key)
-			c.mu.Unlock()
-			cancel()
-		}()
-
-		loaded, loadErr := loadFn(loadCtx)
+		loaded, loadErr := loadFn(ctx)
 		if loadErr != nil {
 			return nil, loadErr
 		}
-		if loadCtx.Err() != nil {
-			// Invalidate ran while loadFn was in flight; the result may reflect
-			// pre-mutation state, so don't let it overwrite the invalidation.
-			return nil, loadCtx.Err()
-		}
 
 		c.mu.Lock()
-		c.data[key] = loaded
+		// Only cache if no Invalidate landed on key since gen was read above; otherwise this
+		// result may reflect pre-mutation state, so leave it uncached and let the next
+		// GetOrLoad start a fresh load under the new generation.
+		if c.generation[key] == gen {
+			c.data[key] = loaded
+		}
 		c.mu.Unlock()
 		return loaded, nil
 	})
@@ -110,15 +108,11 @@ func (c *Cache[T]) GetOrLoad(ctx context.Context, key string, loadFn func(ctx co
 	return v.(T), nil
 }
 
-// Invalidate removes the cached result for key, forcing the next GetOrLoad call
-// to re-fetch from the source.
+// Invalidate removes the cached result for key and bumps its generation, forcing the next
+// GetOrLoad call to start a fresh load rather than reusing one already in flight.
 func (c *Cache[T]) Invalidate(key string) {
 	c.mu.Lock()
 	delete(c.data, key)
-	cancel, ok := c.cancels[key]
+	c.generation[key]++
 	c.mu.Unlock()
-	if ok {
-		cancel()
-	}
-	c.group.Forget(key)
 }

--- a/pkg/internal/provider/cache_test.go
+++ b/pkg/internal/provider/cache_test.go
@@ -292,13 +292,15 @@ func TestCache_CancelingCallerCtxCancelsLoad(t *testing.T) {
 	assert.Equal(t, 42, result)
 }
 
-// TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller reproduces a race hit in
-// production: two resource instances share a cache key (e.g. two snowflake_grant_ownership
+// TestCache_InvalidateDuringInFlightLoadDoesNotErrorAndLeavesResultUncached reproduces a race hit
+// in production: two resource instances share a cache key (e.g. two snowflake_grant_ownership
 // future grants on the same schema). One (simulated by the Invalidate call below) finishes its
 // own mutation and invalidates the key while the other is still mid-load for that same key. The
 // in-flight caller must still get its value back with no error — an unrelated sibling's mutation
-// is not this caller's failure to report.
-func TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller(t *testing.T) {
+// is not this caller's failure to report. The in-flight load's result must also not be cached,
+// since it may reflect pre-mutation state: the next GetOrLoad must perform a fresh load rather
+// than serving that stale value back.
+func TestCache_InvalidateDuringInFlightLoadDoesNotErrorAndLeavesResultUncached(t *testing.T) {
 	cache := NewCache[int]()
 
 	started := make(chan struct{})
@@ -307,15 +309,13 @@ func TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller(t *testi
 	var wg sync.WaitGroup
 	var result int
 	var err error
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		result, err = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
 			close(started)
 			<-proceed
-			return 42, nil
+			return 1, nil // pre-mutation value
 		})
-	}()
+	})
 
 	<-started
 	cache.Invalidate("ROLE_A") // a sibling's mutation lands while the load above is in flight
@@ -324,41 +324,68 @@ func TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller(t *testi
 	waitTimeout(t, &wg, 5*time.Second)
 
 	require.NoError(t, err, "an unrelated Invalidate must not surface as an error to a caller whose load was already in flight")
-	assert.Equal(t, 42, result)
-}
-
-// TestCache_InvalidateDuringInFlightLoadPreventsCachingStaleResult proves the other half of the
-// same fix: the in-flight load's result must not be cached once it raced an Invalidate for its
-// key, since it may reflect pre-mutation state. The next GetOrLoad must perform a fresh load
-// rather than serving that stale value back.
-func TestCache_InvalidateDuringInFlightLoadPreventsCachingStaleResult(t *testing.T) {
-	cache := NewCache[int]()
-
-	started := make(chan struct{})
-	proceed := make(chan struct{})
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, _ = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
-			close(started)
-			<-proceed
-			return 1, nil // pre-mutation value
-		})
-	}()
-
-	<-started
-	cache.Invalidate("ROLE_A")
-	close(proceed)
-	waitTimeout(t, &wg, 5*time.Second)
+	assert.Equal(t, 1, result)
 
 	calls := 0
-	result, err := cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+	result, err = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
 		calls++
 		return 2, nil // post-mutation value
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls, "the stale in-flight result must not have been cached, so this call must perform a fresh load")
 	assert.Equal(t, 2, result)
+}
+
+// TestCache_GetOrLoadAfterInvalidateStartsFreshLoadWithoutJoiningOldFlight proves that a
+// GetOrLoad issued after Invalidate does not join the load already in flight from before the
+// Invalidate: it must start its own loadFn call immediately rather than waiting for the old,
+// pre-invalidation load to finish (which, since generations differ, would never even deliver it
+// that load's result).
+func TestCache_GetOrLoadAfterInvalidateStartsFreshLoadWithoutJoiningOldFlight(t *testing.T) {
+	cache := NewCache[int]()
+
+	started1 := make(chan struct{})
+	proceed1 := make(chan struct{})
+	started2 := make(chan struct{})
+
+	var wg sync.WaitGroup
+	var result1, result2 int
+	var err1, err2 error
+
+	wg.Go(func() {
+		result1, err1 = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+			close(started1)
+			<-proceed1
+			return 1, nil // pre-mutation value
+		})
+	})
+
+	<-started1
+	cache.Invalidate("ROLE_A")
+
+	calls := 0
+	wg.Go(func() {
+		result2, err2 = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+			calls++
+			close(started2)
+			return 2, nil // post-mutation value
+		})
+	})
+
+	// If the second GetOrLoad joined the first (pre-Invalidate) singleflight call instead of
+	// starting a fresh one under the new generation, its loadFn would never run and started2
+	// would never close while proceed1 is still blocking the first load.
+	select {
+	case <-started2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the post-Invalidate GetOrLoad to start its own load; it may have joined the pre-Invalidate in-flight call instead")
+	}
+	close(proceed1)
+	waitTimeout(t, &wg, 5*time.Second)
+
+	require.NoError(t, err1)
+	assert.Equal(t, 1, result1)
+	require.NoError(t, err2)
+	assert.Equal(t, 2, result2)
+	assert.Equal(t, 1, calls)
 }

--- a/pkg/internal/provider/cache_test.go
+++ b/pkg/internal/provider/cache_test.go
@@ -260,7 +260,7 @@ func TestCache_CallerCtxPropagatesToLoadFn(t *testing.T) {
 }
 
 // TestCache_CancelingCallerCtxCancelsLoad proves that canceling the ctx passed to GetOrLoad
-// cancels the in-flight loadFn (via the ctx.WithCancel derivation), and that the resulting
+// cancels the in-flight loadFn, since ctx is passed to it unchanged, and that the resulting
 // error is surfaced to the caller rather than a stale/partial result being cached.
 func TestCache_CancelingCallerCtxCancelsLoad(t *testing.T) {
 	cache := NewCache[int]()
@@ -290,4 +290,75 @@ func TestCache_CancelingCallerCtxCancelsLoad(t *testing.T) {
 	result, err := cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) { return 42, nil })
 	require.NoError(t, err)
 	assert.Equal(t, 42, result)
+}
+
+// TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller reproduces a race hit in
+// production: two resource instances share a cache key (e.g. two snowflake_grant_ownership
+// future grants on the same schema). One (simulated by the Invalidate call below) finishes its
+// own mutation and invalidates the key while the other is still mid-load for that same key. The
+// in-flight caller must still get its value back with no error — an unrelated sibling's mutation
+// is not this caller's failure to report.
+func TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller(t *testing.T) {
+	cache := NewCache[int]()
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+
+	var wg sync.WaitGroup
+	var result int
+	var err error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		result, err = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+			close(started)
+			<-proceed
+			return 42, nil
+		})
+	}()
+
+	<-started
+	cache.Invalidate("ROLE_A") // a sibling's mutation lands while the load above is in flight
+	close(proceed)
+
+	waitTimeout(t, &wg, 5*time.Second)
+
+	require.NoError(t, err, "an unrelated Invalidate must not surface as an error to a caller whose load was already in flight")
+	assert.Equal(t, 42, result)
+}
+
+// TestCache_InvalidateDuringInFlightLoadPreventsCachingStaleResult proves the other half of the
+// same fix: the in-flight load's result must not be cached once it raced an Invalidate for its
+// key, since it may reflect pre-mutation state. The next GetOrLoad must perform a fresh load
+// rather than serving that stale value back.
+func TestCache_InvalidateDuringInFlightLoadPreventsCachingStaleResult(t *testing.T) {
+	cache := NewCache[int]()
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+			close(started)
+			<-proceed
+			return 1, nil // pre-mutation value
+		})
+	}()
+
+	<-started
+	cache.Invalidate("ROLE_A")
+	close(proceed)
+	waitTimeout(t, &wg, 5*time.Second)
+
+	calls := 0
+	result, err := cache.GetOrLoad(context.Background(), "ROLE_A", func(context.Context) (int, error) {
+		calls++
+		return 2, nil // post-mutation value
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "the stale in-flight result must not have been cached, so this call must perform a fresh load")
+	assert.Equal(t, 2, result)
 }


### PR DESCRIPTION
Refs #5170

## Summary

`Cache[T].Invalidate(key)` cancelled the `singleflight`-shared context of whatever load was currently in flight for that key. Because `singleflight.Group.Do` collapses concurrent misses on the same key into one `loadFn` call shared by every joined caller, this cancelled the load for **all** of them — not just whichever caller mutated the underlying object and triggered the invalidation. A concurrent caller with no relation to that mutation received `context.Canceled` from `GetOrLoad` instead of its value.

This surfaces whenever two or more resource instances resolve to the same cache key (the caching experiments' own canonical use case — many grant resources sharing one role/object/container) and one of them mutates/invalidates while another is still loading that same key for the first time. That's not a corner case: it's exactly the shape Terraform's parallel resource graph walk produces at any nontrivial `-parallelism`.

### Example

Two `snowflake_grant_ownership` resources grant future ownership on different object types in the *same new schema* — say `future_view_ownership` and `future_procedure_ownership` on `MY_DB.MY_SCHEMA`. Both resolve to the same cache key, since the key is the rendered SQL of the `SHOW FUTURE GRANTS IN SCHEMA MY_DB.MY_SCHEMA` statement, and Terraform applies them concurrently (no dependency between them):

1. `future_view_ownership`'s `Create` succeeds, then calls `Invalidate` on the shared key so its own trailing `Read` observes the new grant.
2. At that exact moment, `future_procedure_ownership` — whose own `Create` had already succeeded moments earlier — is mid-flight in its own trailing `Read`, which is a cache miss doing the real `SHOW FUTURE GRANTS` round trip for the *same* key.
3. `future_view_ownership`'s `Invalidate` cancels the shared `loadCtx`, killing `future_procedure_ownership`'s in-flight load too.
4. `future_procedure_ownership`'s `Read` gets `context.Canceled`, is treated as "not found", and calls `d.SetId("")`.
5. Terraform's apply-time consistency check compares the post-`Create` planned value against this now-empty post-`Read` state and fails the apply: `Provider produced inconsistent result after apply: Root object was present, but now absent.`
6. Because the apply errored, `future_procedure_ownership` is never written to state — even though its `GRANT OWNERSHIP ... ON FUTURE PROCEDURES ...` had already executed successfully. The next apply attempts to re-create it and Snowflake correctly rejects the duplicate future grant (`003504`), leaving the operator with orphaned state requiring a manual `terraform import` to recover.

This reproduces with any two grant resources (`snowflake_grant_account_role`, `snowflake_grant_privileges_to_account_role`, `snowflake_grant_ownership`) that share a cache key under `GRANTS_SHOW_CACHING`, `GRANT_ACCOUNT_ROLE_SHOW_CACHING`, or `ACCOUNT_ROLE_SHOW_CACHING` — all three are built on the same `Cache[T]` and hit the identical defect.

## References

- #4855 — introduced `Cache[T]` and the `cancels map[string]context.CancelFunc` mechanism this PR removes, for `GRANT_ACCOUNT_ROLE_SHOW_CACHING`
- #5095 — migrated `GRANT_ACCOUNT_ROLE_SHOW_CACHING` onto the shared `Cache[T]` and added `GRANTS_SHOW_CACHING`, both affected by the same defect
- #5096 — added `ACCOUNT_ROLE_SHOW_CACHING` on the same `Cache[T]`, also affected

## Changes

Replaces the `cancels map[string]context.CancelFunc` mechanism with a per-key generation counter, folded into the `singleflight` key itself:

- `Invalidate(key)` bumps `generation[key]` instead of cancelling anything.
- `GetOrLoad` captures the current generation before starting a load and folds it into the key passed to `singleflight.Group.Do` (`fmt.Sprintf("%d:%s", gen, key)`). A concurrent `Invalidate` therefore starts a brand-new singleflight group for that key rather than joining — or having to cancel — whatever's already in flight for it.
- A load already in flight is now allowed to complete normally. Its result is written to `data` only if the generation hasn't moved since the load started; otherwise it's simply left uncached (the result may reflect pre-mutation state) and the next `GetOrLoad` performs a fresh load under the new generation, rather than the previous behaviour of force-cancelling the load into an error.
- `loadFn` now receives `ctx` unchanged instead of a `context.WithCancel`-derived one — no longer needed, since `Invalidate` no longer needs a cancel hook. External cancellation (a resource `Timeout`, or the caller's own context being cancelled) still propagates exactly as it would for a direct call to `loadFn`.

### How the fix was derived

The initial instinct was a generation map checked *after* the load completes, with an explicit retry loop in `GetOrLoad` for callers whose load raced an invalidation. Before implementing that, we looked for how this exact problem — "invalidate a key while a `singleflight`-deduplicated load for it is in flight, without erroring out unrelated concurrent joiners" — is handled elsewhere:

- `golang.org/x/sync/singleflight`'s own `Forget` doc is explicit that `Forget` only affects *future* callers of `Do`, never ones already joined to an in-flight call — confirming the previous `cancels` map was trying to make `Invalidate` do something `singleflight` was never designed to support directly.
- A close real-world precedent (a `singleflight`-backed TTL cache with a generation/epoch counter bumped on invalidation) folds the generation directly into the `singleflight` key rather than tracking it separately and retrying after the fact — a fetch in flight at invalidation time is simply allowed to finish, with its result dropped instead of written back, rather than forced to fail. That's a smaller, simpler shape than a separate generation map plus a post-hoc staleness check and retry loop, so we adopted it here instead.
- We also checked whether a mainstream Go caching library already solves this so we wouldn't need to hand-roll it. None of the ones surveyed (a Caffeine-inspired high-performance cache, a stampede-protection-focused cache, a bare LRU commonly paired with `singleflight` by hand) document or guarantee this behaviour — the closest one explicitly calls invalidate-during-load "undefined". Given the cache here is small, process-scoped to a single plan/apply run, and `x/sync/singleflight` is already a dependency, a minimal local fix was the better fit than adding a new dependency for a guarantee no library actually provides.

### Correctness

No change to the property that matters: a resource's own `Create`/`Update`/`Delete` always invalidates *before* its own trailing `Read`, so its own generation snapshot is always taken post-invalidation and it's guaranteed a fresh load reflecting its own mutation. What's removed is a failure mode where an *unrelated* concurrent caller's otherwise-valid, in-progress read got aborted into a hard error — that never bought any additional consistency guarantee (the mutating SQL had typically already succeeded by the time the cancellation fired), it just turned a bounded, self-healing staleness window (resolved by the next plan's fresh refresh, same as any out-of-band Snowflake change) into an outright apply failure with, in the worst case, permanent orphaned state.

### Parallelism / plan-speedup impact

None to the caching feature's actual benefit. The mechanism that provides the speedup — concurrent misses on the *same* key collapsing into one `loadFn` call, misses on *different* keys proceeding fully in parallel — is untouched. The only behavioural change is scoped to the rare window where a key is read for the first time at the exact moment a sibling mutates it: previously that meant a cancelled, failed apply; now it means, at most, one extra live `SHOW` call for that specific key when some other resource reads it again afterward. Given a failed apply requires a full manual re-run, this is a clear net improvement in real-world plan/apply wall-clock time, not just correctness.

## Tests

Added to `pkg/internal/provider/cache_test.go`, following the existing channel/barrier style:

- `TestCache_InvalidateDuringInFlightLoadDoesNotErrorConcurrentCaller` — the primary regression test. Starts a load, confirms it's running, invalidates the key while it's still in flight, then lets it complete. Asserts the caller gets its value with no error. Verified this fails against the pre-fix code (`context canceled`) and passes against the fix.
- `TestCache_InvalidateDuringInFlightLoadPreventsCachingStaleResult` — proves the complementary half: the in-flight load's result is not cached once it raced an invalidation, so a subsequent `GetOrLoad` performs a real fresh load rather than serving the stale value back.

All existing `Cache` tests continue to pass unchanged, including the concurrency-shape tests (`TestCache_ConcurrentMissesOnSameKeyCollapseToOneLoad`, `TestCache_ConcurrentMissesOnDifferentKeysRunInParallel`) and the caller-context propagation/cancellation tests.

Ran locally (no live Snowflake account needed for any of this):
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -v ./pkg/internal/provider/...` — all tests pass under the race detector
- `go test ./pkg/resources/... ./pkg/provider/... ./pkg/internal/provider/...` — all green, confirming nothing calling into `Cache[T]` regressed